### PR TITLE
Gstreamer plugin

### DIFF
--- a/CMakeLists.gst_avb_video_plugin.txt
+++ b/CMakeLists.gst_avb_video_plugin.txt
@@ -12,6 +12,7 @@ if (${GST_VIDEO_FOUND})
         private/src/gst/gstavbplugin.cpp
         private/src/gst/gstavbclock.cpp
         private/src/gst/gstavbvideosink.cpp
+        private/src/gst/gstavbvideosrc.cpp
     )
 
     target_link_libraries( ias-media_transport-gst_avb_video_plugin ${GST_VIDEO_LDFLAGS} ias-media_transport-avb_video_bridge)

--- a/CMakeLists.gst_avb_video_plugin.txt
+++ b/CMakeLists.gst_avb_video_plugin.txt
@@ -10,6 +10,7 @@ if (${GST_VIDEO_FOUND})
 
     add_library( ias-media_transport-gst_avb_video_plugin SHARED
         private/src/gst/gstavbplugin.cpp
+        private/src/gst/gstavbclock.cpp
         private/src/gst/gstavbvideosink.cpp
     )
 

--- a/CMakeLists.gst_avb_video_plugin.txt
+++ b/CMakeLists.gst_avb_video_plugin.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2018 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+find_package( PkgConfig )
+pkg_check_modules( GST_VIDEO gstreamer-video-1.0 )
+
+if (${GST_VIDEO_FOUND})
+
+    add_library( ias-media_transport-gst_avb_video_plugin SHARED
+        private/src/gst/gstavbplugin.cpp
+        private/src/gst/gstavbvideosink.cpp
+    )
+
+    target_link_libraries( ias-media_transport-gst_avb_video_plugin ${GST_VIDEO_LDFLAGS} ias-media_transport-avb_video_bridge)
+    target_compile_options ( ias-media_transport-gst_avb_video_plugin PUBLIC -fPIC ${GST_VIDEO_CFLAGS_OTHER})
+    target_include_directories( ias-media_transport-gst_avb_video_plugin PUBLIC ${GST_VIDEO_INCLUDE_DIRS})
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ include( CMakeLists.avb_clockdriver.txt )
 include( CMakeLists.avb_streamhandler_demo.txt )
 include( CMakeLists.avb_video_bridge.txt )
 include( CMakeLists.avb_video_debug_app.txt )
+include( CMakeLists.gst_avb_video_plugin.txt )
 
 #------------------------------------------------------------------
 #Include makefile building internal tools (only on host / not needed on target)

--- a/private/inc/gst/gstavbclock.h
+++ b/private/inc/gst/gstavbclock.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _GST_AVBCLOCK_H_
+#define _GST_AVBCLOCK_H_
+
+#include <gst/gstsystemclock.h>
+
+#include "media_transport/avb_video_bridge/IasAvbVideoBridge.h"
+
+#include <time.h>
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_AVBCLOCK   (gst_avbclock_get_type())
+#define GST_AVBCLOCK(obj)   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_AVBCLOCK,GstAvbClock))
+#define GST_AVBCLOCK_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_AVBCLOCK,GstAvbClockClass))
+#define GST_IS_AVBCLOCK(obj)   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_AVBCLOCK))
+#define GST_IS_AVBCLOCK_CLASS(obj)   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_AVBCLOCK))
+
+typedef struct _GstAvbClock GstAvbClock;
+typedef struct _GstAvbClockClass GstAvbClockClass;
+
+struct _GstAvbClock
+{
+    GstSystemClock base_avbclock;
+
+    clockid_t clock_id;
+    int device_fd;
+};
+
+struct _GstAvbClockClass
+{
+    GstSystemClockClass base_avbclocklass;
+};
+
+GType gst_avbclock_get_type(void);
+GstClock *gst_avbclock_obtain(void);
+GstClockTime gst_avbclock_avtp_timestamp_to_pts(unsigned avtp_timestamp, GstClockTime start_time);
+
+G_END_DECLS
+
+#endif

--- a/private/inc/gst/gstavbvideosink.h
+++ b/private/inc/gst/gstavbvideosink.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _GST_AVBVIDEOSINK_H_
+#define _GST_AVBVIDEOSINK_H_
+
+#include <gst/base/gstbasesink.h>
+
+#include "media_transport/avb_video_bridge/IasAvbVideoBridge.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_AVBVIDEOSINK   (gst_avbvideosink_get_type())
+#define GST_AVBVIDEOSINK(obj)   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_AVBVIDEOSINK,GstAvbVideoSink))
+#define GST_AVBVIDEOSINK_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_AVBVIDEOSINK,GstAvbVideoSinkClass))
+#define GST_IS_AVBVIDEOSINK(obj)   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_AVBVIDEOSINK))
+#define GST_IS_AVBVIDEOSINK_CLASS(obj)   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_AVBVIDEOSINK))
+
+typedef struct _GstAvbVideoSink GstAvbVideoSink;
+typedef struct _GstAvbVideoSinkClass GstAvbVideoSinkClass;
+
+struct _GstAvbVideoSink
+{
+    GstBaseSink base_avbvideosink;
+
+    struct ias_avbvideobridge_sender *sender;
+    gchar *stream_name;
+};
+
+struct _GstAvbVideoSinkClass
+{
+    GstBaseSinkClass base_avbvideosink_class;
+};
+
+GType gst_avbvideosink_get_type(void);
+
+G_END_DECLS
+
+#endif

--- a/private/inc/gst/gstavbvideosrc.h
+++ b/private/inc/gst/gstavbvideosrc.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _GST_AVBVIDEOSRC_H_
+#define _GST_AVBVIDEOSRC_H_
+
+#include <gst/base/gstpushsrc.h>
+
+#include "media_transport/avb_video_bridge/IasAvbVideoBridge.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_AVBVIDEOSRC   (gst_avbvideosrc_get_type())
+#define GST_AVBVIDEOSRC(obj)   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_AVBVIDEOSRC,GstAvbVideoSrc))
+#define GST_AVBVIDEOSRC_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_AVBVIDEOSRC,GstAvbVideoSrcClass))
+#define GST_IS_AVBVIDEOSRC(obj)   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_AVBVIDEOSRC))
+#define GST_IS_AVBVIDEOSRC_CLASS(obj)   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_AVBVIDEOSRC))
+
+typedef struct _GstAvbVideoSrc GstAvbVideoSrc;
+typedef struct _GstAvbVideoSrcClass GstAvbVideoSrcClass;
+
+struct _GstAvbVideoSrc
+{
+    GstPushSrc base_avbvideosrc;
+
+    struct ias_avbvideobridge_receiver *receiver;
+    GAsyncQueue *queue;
+    gchar *stream_name;
+    gboolean done;
+};
+
+struct _GstAvbVideoSrcClass
+{
+    GstPushSrcClass base_avbvideosrc_class;
+};
+
+GType gst_avbvideosrc_get_type(void);
+
+G_END_DECLS
+
+#endif

--- a/private/src/avb_configuration_reference/IasAvbConfigReference.cpp
+++ b/private/src/avb_configuration_reference/IasAvbConfigReference.cpp
@@ -96,6 +96,7 @@ StreamParamsAvbRx Unittest2chSetupAvbRxNC[] =
 StreamParamsAvbVideoTx VideoPocSetupAvbVideoMpegTsMasterTx[] =
 {
     { 'L', 4000u, 1460, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, cIasAvbPtpClockDomainId, 0x91E0F00007812642u, 0x91E0F0000781u, 501u, true },
+    { 'L', 4000u, 1460, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, cIasAvbPtpClockDomainId, 0x91E0F00007812643u, 0x91E0F0000782u, 502u, true },
     cTerminator_StreamParamsAvbVideoTx
 };
 
@@ -111,6 +112,7 @@ StreamParamsAvbVideoTx VideoPocSetupAvbVideoMasterTx[] =
 StreamParamsAvbVideoRx VideoPocSetupAvbVideoMpegTsMasterRx[] =
 {
    { 'L', 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, 0x91E0F00007852646u, 0x91E0F0000785u, 507u },
+   { 'L', 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, 0x91E0F00007852647u, 0x91E0F0000786u, 508u },
    cTerminator_StreamParamsAvbVideoRx
 };
 
@@ -128,7 +130,9 @@ StreamParamsAvbVideoRx VideoPocSetupAvbVideoMasterRx[] =
 StreamParamsVideo VideoPocSetupLocalVideoMpegTsMaster[] =
 {
     { IasAvbStreamDirection::eIasAvbTransmitToNetwork, 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.1", 501u },
+    { IasAvbStreamDirection::eIasAvbTransmitToNetwork, 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.2", 502u },
     { IasAvbStreamDirection::eIasAvbReceiveFromNetwork,4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.7", 507u },
+    { IasAvbStreamDirection::eIasAvbReceiveFromNetwork,4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.8", 508u },
     cTerminator_StreamParamsVideo
 };
 
@@ -150,6 +154,7 @@ StreamParamsVideo VideoPocSetupLocalVideoMaster[] =
 StreamParamsAvbVideoTx VideoPocSetupAvbVideoMpegTsSlaveTx[] =
 {
     { 'L', 4000u, 1460, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, cIasAvbPtpClockDomainId, 0x91E0F00007852646u, 0x91E0F0000785u, 501u, true },
+    { 'L', 4000u, 1460, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, cIasAvbPtpClockDomainId, 0x91E0F00007852647u, 0x91E0F0000786u, 502u, true },
     cTerminator_StreamParamsAvbVideoTx
 };
 
@@ -165,6 +170,7 @@ StreamParamsAvbVideoTx VideoPocSetupAvbVideoSlaveTx[] =
 StreamParamsAvbVideoRx VideoPocSetupAvbVideoMpegTsSlaveRx[] =
 {
    { 'L', 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, 0x91E0F00007812642u, 0x91E0F0000781u, 507u },
+   { 'L', 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, 0x91E0F00007812643u, 0x91E0F0000782u, 508u },
    cTerminator_StreamParamsAvbVideoRx
 };
 
@@ -182,7 +188,9 @@ StreamParamsAvbVideoRx VideoPocSetupAvbVideoSlaveRx[] =
 StreamParamsVideo VideoPocSetupLocalVideoMpegTsSlave[] =
 {
     { IasAvbStreamDirection::eIasAvbTransmitToNetwork, 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.1", 501u },
+    { IasAvbStreamDirection::eIasAvbTransmitToNetwork, 4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.2", 502u },
     { IasAvbStreamDirection::eIasAvbReceiveFromNetwork,4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.7", 507u },
+    { IasAvbStreamDirection::eIasAvbReceiveFromNetwork,4000u, 1460u, IasAvbVideoFormat::eIasAvbVideoFormatIec61883, "media_transport.avb.mpegts_streaming.8", 508u },
     cTerminator_StreamParamsVideo
 };
 

--- a/private/src/gst/gstavbclock.cpp
+++ b/private/src/gst/gstavbclock.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gst/gst.h>
+#include "gst/gstavbclock.h"
+
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#define NSEC_PER_SEC 1000000000ULL
+// Stolen from <linux-src>/include/linux/posix-timers.h
+#define FD_TO_CLOCKID(FD) ((~FD) << 3) | 3;
+
+GST_DEBUG_CATEGORY_STATIC(gst_avbclock_debug_category);
+#define GST_CAT_DEFAULT gst_avbclock_debug_category
+
+static GstClock *g_avbclock_singleton;
+
+static GstClockTime gst_avbclock_get_internal_time(GstClock *object);
+
+G_DEFINE_TYPE_WITH_CODE(GstAvbClock, gst_avbclock, GST_TYPE_SYSTEM_CLOCK,
+        GST_DEBUG_CATEGORY_INIT(gst_avbclock_debug_category, "avbclock", 0,
+            "debug category for avbclock element"));
+
+static void
+gst_avbclock_class_init(GstAvbClockClass * klass)
+{
+  GstClockClass *gstclock_class = GST_CLOCK_CLASS(klass);
+
+  gstclock_class->get_internal_time = gst_avbclock_get_internal_time;
+}
+
+static void
+gst_avbclock_init(GstAvbClock *avbclock)
+{
+    avbclock->device_fd = -1;
+    avbclock->clock_id = -1;
+}
+
+static GstClockTime
+gst_avbclock_get_internal_time(GstClock *object)
+{
+    GstAvbClock *avbclock = GST_AVBCLOCK(object);
+
+    struct timespec ts;
+    clock_gettime(avbclock->clock_id, &ts);
+    GstClockTime time = GST_TIMESPEC_TO_TIME(ts);
+    GST_DEBUG_OBJECT(avbclock, "Internal time: %lu", time);
+    return time;
+}
+
+GstClockTime
+gst_avbclock_avtp_timestamp_to_pts(unsigned avtp_timestamp, GstClockTime start_time)
+{
+    GstAvbClock *avbclock = GST_AVBCLOCK(gst_avbclock_obtain());
+
+    struct timespec ts;
+    clock_gettime(avbclock->clock_id, &ts);
+
+    // Idea is to check how far in the future avtp_timestamp is compared to current avtp_timestamp
+    // Modulo 2^32 is used to account for avtp_timestamp smaller than current avtp_timestamp
+    unsigned current_avtp_timestamp = (unsigned)((ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec) % (1ULL << 32));
+    GstClockTime pts = (avtp_timestamp - current_avtp_timestamp) % (1ULL << 32);
+
+    GstClockTime now = GST_TIMESPEC_TO_TIME(ts);
+
+    // Final pts is relative to running time, the time the pipeline is in PLAYING state
+    return pts + (now - start_time);
+}
+
+static bool
+open_clock(GstClock *object)
+{
+    GstAvbClock *avbclock = GST_AVBCLOCK(object);
+
+    //TODO: get ptp device from network device or some configuration
+    avbclock->device_fd = open("/dev/ptp0", O_RDONLY);
+    if (avbclock->device_fd >= 0) {
+        avbclock->clock_id = FD_TO_CLOCKID(avbclock->device_fd);
+        if (avbclock->clock_id != -1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+GstClock *
+gst_avbclock_obtain(void)
+{
+    static GMutex avbclock_mutex;
+
+    g_mutex_lock(&avbclock_mutex);
+
+    if (g_avbclock_singleton == NULL) {
+        GstClock *clock = (GstClock *)g_object_new(GST_TYPE_AVBCLOCK, "name", "GstAvbClock", NULL);
+        if (open_clock(clock)) {
+            g_avbclock_singleton = clock;
+        }
+    } else {
+        g_object_ref(g_avbclock_singleton);
+    }
+
+    g_mutex_unlock(&avbclock_mutex);
+
+    return g_avbclock_singleton;
+}

--- a/private/src/gst/gstavbplugin.cpp
+++ b/private/src/gst/gstavbplugin.cpp
@@ -5,12 +5,15 @@
  */
 #include <gst/gst.h>
 #include "gst/gstavbvideosink.h"
+#include "gst/gstavbvideosrc.h"
 
 static gboolean
 plugin_init(GstPlugin * plugin)
 {
     gst_element_register(plugin, "avbvideosink", GST_RANK_NONE,
             GST_TYPE_AVBVIDEOSINK);
+    gst_element_register(plugin, "avbvideosrc", GST_RANK_NONE,
+            GST_TYPE_AVBVIDEOSRC);
 
     return TRUE;
 }

--- a/private/src/gst/gstavbplugin.cpp
+++ b/private/src/gst/gstavbplugin.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <gst/gst.h>
+#include "gst/gstavbvideosink.h"
+
+static gboolean
+plugin_init(GstPlugin * plugin)
+{
+    gst_element_register(plugin, "avbvideosink", GST_RANK_NONE,
+            GST_TYPE_AVBVIDEOSINK);
+
+    return TRUE;
+}
+
+#ifndef VERSION
+#define VERSION "0.0.1"
+#endif
+#ifndef PACKAGE
+#define PACKAGE "gstreamer-avb"
+#endif
+#ifndef PACKAGE_NAME
+#define PACKAGE_NAME "gst_avb_plugin"
+#endif
+#ifndef GST_PACKAGE_ORIGIN
+#define GST_PACKAGE_ORIGIN "http://01.org/"
+#endif
+
+GST_PLUGIN_DEFINE(GST_VERSION_MAJOR,
+        GST_VERSION_MINOR,
+        ias_media_transport_gst_avb_video_plugin,
+        "AVB-SH GStreamer plugin sample",
+        plugin_init, VERSION, "BSD", PACKAGE_NAME, GST_PACKAGE_ORIGIN)

--- a/private/src/gst/gstavbvideosink.cpp
+++ b/private/src/gst/gstavbvideosink.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gst/gst.h>
+#include <gst/base/gstbasesink.h>
+#include "gst/gstavbvideosink.h"
+
+GST_DEBUG_CATEGORY_STATIC(gst_avbvideosink_debug_category);
+#define GST_CAT_DEFAULT gst_avbvideosink_debug_category
+
+#define DEFAULT_STREAM_NAME "media_transport.avb.mpegts_streaming.1"
+#define MPEG_TS_PACKET_SIZE 188
+
+/* prototypes */
+
+static void gst_avbvideosink_finalize(GObject *object);
+
+static GstFlowReturn gst_avbvideosink_render(GstBaseSink *sink,
+        GstBuffer *buffer);
+
+static void gst_avbvideosink_set_property(GObject *object, guint prop_id,
+        const GValue *value, GParamSpec *pspec);
+static void gst_avbvideosink_get_property(GObject *object, guint prop_id,
+        GValue *value, GParamSpec *pspec);
+static GstStateChangeReturn gst_avbvideosink_change_state(GstElement *element,
+        GstStateChange transition);
+
+enum
+{
+    PROP_0,
+    PROP_STREAM_NAME
+};
+
+/* pad templates */
+
+static GstStaticPadTemplate gst_avbvideosink_sink_template =
+GST_STATIC_PAD_TEMPLATE("sink",
+        GST_PAD_SINK,
+        GST_PAD_ALWAYS,
+        GST_STATIC_CAPS(
+            "video/mpegts,"
+            "  packetsize = (int) " G_STRINGIFY(MPEG_TS_PACKET_SIZE)
+            )
+        );
+
+
+/* class initialization */
+
+G_DEFINE_TYPE_WITH_CODE(GstAvbVideoSink, gst_avbvideosink, GST_TYPE_BASE_SINK,
+        GST_DEBUG_CATEGORY_INIT(gst_avbvideosink_debug_category, "avbvideosink", 0,
+            "debug category for avbvideosink element"));
+
+static void
+gst_avbvideosink_class_init(GstAvbVideoSinkClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+    GstElementClass *gstelement_class = GST_ELEMENT_CLASS(klass);
+    GstBaseSinkClass *base_sink_class = GST_BASE_SINK_CLASS(klass);
+
+    /* Setting up pads and setting metadata should be moved to
+       base_class_init if you intend to subclass this class. */
+    gst_element_class_add_static_pad_template(GST_ELEMENT_CLASS(klass),
+            &gst_avbvideosink_sink_template);
+
+    gst_element_class_set_static_metadata(GST_ELEMENT_CLASS(klass),
+            "AVB-SH Sink", "Sink/Video/Network", "Sends MPEG-TS packets to AVB-SH",
+            "Intel");
+
+    gobject_class->finalize = gst_avbvideosink_finalize;
+    gobject_class->set_property = gst_avbvideosink_set_property;
+    gobject_class->get_property = gst_avbvideosink_get_property;
+
+    gstelement_class->change_state = gst_avbvideosink_change_state;
+
+    base_sink_class->render = GST_DEBUG_FUNCPTR(gst_avbvideosink_render);
+    // TODO render_list, if available, is used when using mpegtsmux before
+    // avbvideosink in the pipeline.
+    //  base_sink_class->render_list = GST_DEBUG_FUNCPTR(gst_avbvideosink_render_list);
+
+    g_object_class_install_property(gobject_class, PROP_STREAM_NAME,
+            g_param_spec_string("stream-name", "Stream name",
+                "Name of the stream", DEFAULT_STREAM_NAME,
+                (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+}
+
+static void gst_avbvideosink_set_property(GObject *object, guint prop_id,
+        const GValue *value, GParamSpec *pspec)
+{
+    GstAvbVideoSink *avbvideosink = GST_AVBVIDEOSINK(object);
+    (void)pspec;
+
+    if (prop_id == PROP_STREAM_NAME) {
+        free(avbvideosink->stream_name);
+        avbvideosink->stream_name = g_value_dup_string(value);
+        GST_DEBUG_OBJECT(avbvideosink, "Set stream name to [%s]", avbvideosink->stream_name);
+    }
+}
+
+static void gst_avbvideosink_get_property(GObject *object, guint prop_id,
+        GValue *value, GParamSpec *pspec)
+{
+    GstAvbVideoSink *avbvideosink = GST_AVBVIDEOSINK(object);
+
+    if (prop_id == PROP_STREAM_NAME) {
+        g_value_set_string(value, avbvideosink->stream_name);
+    } else {
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static GstStateChangeReturn
+gst_avbvideosink_change_state(GstElement *element, GstStateChange transition)
+{
+    GstAvbVideoSink *avbvideosink = GST_AVBVIDEOSINK(element);
+    GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+
+    if (transition == GST_STATE_CHANGE_NULL_TO_READY) {
+        avbvideosink->sender = ias_avbvideobridge_create_sender(avbvideosink->stream_name);
+        if (!avbvideosink->sender) {
+            GST_ERROR_OBJECT(avbvideosink, "Could not create avbvideobridge sender [%s]", avbvideosink->stream_name);
+            return GST_STATE_CHANGE_FAILURE;
+        }
+    }
+
+    ret = GST_ELEMENT_CLASS(gst_avbvideosink_parent_class)->change_state(element, transition);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+        if (transition == GST_STATE_CHANGE_NULL_TO_READY) {
+            ias_avbvideobridge_destroy_sender(avbvideosink->sender);
+            avbvideosink->sender = NULL;
+        }
+        return ret;
+    }
+
+    if (transition == GST_STATE_CHANGE_READY_TO_NULL) {
+        ias_avbvideobridge_destroy_sender(avbvideosink->sender);
+        avbvideosink->sender = NULL;
+    }
+
+    return ret;
+}
+
+static void
+gst_avbvideosink_init(GstAvbVideoSink *avbvideosink)
+{
+    avbvideosink->stream_name = strdup(DEFAULT_STREAM_NAME);
+}
+
+void
+gst_avbvideosink_finalize(GObject * object)
+{
+    GstAvbVideoSink *avbvideosink = GST_AVBVIDEOSINK(object);
+
+    free(avbvideosink->stream_name);
+    avbvideosink->stream_name = NULL;
+
+    G_OBJECT_CLASS(gst_avbvideosink_parent_class)->finalize(object);
+}
+
+static GstFlowReturn
+gst_avbvideosink_render(GstBaseSink * sink, GstBuffer * buffer)
+{
+    GstAvbVideoSink *avbvideosink = GST_AVBVIDEOSINK(sink);
+    GstMapInfo map;
+    ias_avbvideobridge_result r;
+
+    gst_buffer_map(buffer, &map, GST_MAP_READ);
+
+    gsize size = gst_buffer_get_size(buffer);
+
+    if (size != MPEG_TS_PACKET_SIZE) {
+        // TODO avmux_mpegts doesn't generate 188-bytes packets, but any arbitrary number. It even breaks
+        // a 188-bytes packet so that one call to gst_avbvideosink_render may receive the first part of the
+        // bytes, and the next call receives the remaining bytes. So, these cases, where a muxer
+        // generates "strange" packets, need to be considered.
+        // mpegtsmux otoh, sends to gst_avbvideosink_render only 188 bytes packets.
+        gst_buffer_unmap(buffer, &map);
+        GST_ERROR_OBJECT(avbvideosink,
+                "Handling of MPEG-TS buffers with more than one "
+                G_STRINGIFY(MPEG_TS_PACKET_SIZE) "-byte packets not suppported");
+        return GST_FLOW_NOT_NEGOTIATED;
+    }
+
+    ias_avbvideobridge_buffer avb_buffer;
+    avb_buffer.size = MPEG_TS_PACKET_SIZE;
+    avb_buffer.data = map.data;
+    r = ias_avbvideobridge_send_packet_MpegTs(avbvideosink->sender, false, &avb_buffer);
+
+    GST_DEBUG_OBJECT(avbvideosink, "Sent MPEG-TS packet to avb-sh: %d", r);
+
+    gst_buffer_unmap(buffer, &map);
+
+    return GST_FLOW_OK;
+}

--- a/private/src/gst/gstavbvideosrc.cpp
+++ b/private/src/gst/gstavbvideosrc.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gst/gst.h>
+#include <gst/base/gstbasesrc.h>
+#include "gst/gstavbvideosrc.h"
+#include "gst/gstavbclock.h"
+
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <cstdio>
+
+GST_DEBUG_CATEGORY_STATIC(gst_avbvideosrc_debug_category);
+#define GST_CAT_DEFAULT gst_avbvideosrc_debug_category
+
+#define DEFAULT_STREAM_NAME "media_transport.avb.mpegts_streaming.7"
+#define MPEG_TS_PACKET_SIZE 188
+#define SPH_SIZE 4
+
+/* prototypes */
+
+static GstClock *gst_avbvideosrc_provide_clock(GstElement *element);
+static void gst_avbvideosrc_finalize(GObject * object);
+
+static GstFlowReturn gst_avbvideosrc_create(GstPushSrc * src, GstBuffer ** buf);
+
+static void mpegts_callback(ias_avbvideobridge_receiver *receiver, bool sph, ias_avbvideobridge_buffer const * packet, void *user_ptr);
+
+static void gst_avbvideosrc_set_property(GObject *object, guint prop_id,
+        const GValue *value, GParamSpec *pspec);
+static void gst_avbvideosrc_get_property(GObject *object, guint prop_id,
+        GValue *value, GParamSpec *pspec);
+static GstStateChangeReturn gst_avbvideosrc_change_state(GstElement *element,
+        GstStateChange transition);
+
+enum
+{
+    PROP_0,
+    PROP_STREAM_NAME
+};
+
+/* pad templates */
+
+static GstStaticPadTemplate gst_avbvideosrc_src_template =
+GST_STATIC_PAD_TEMPLATE("src",
+        GST_PAD_SRC,
+        GST_PAD_ALWAYS,
+        GST_STATIC_CAPS(
+            "video/mpegts,"
+            "  packetsize = (int) " G_STRINGIFY(MPEG_TS_PACKET_SIZE) ","
+            "  systemstream = (boolean) true"
+            )
+        );
+
+
+/* class initialization */
+
+G_DEFINE_TYPE_WITH_CODE(GstAvbVideoSrc, gst_avbvideosrc, GST_TYPE_PUSH_SRC,
+        GST_DEBUG_CATEGORY_INIT(gst_avbvideosrc_debug_category, "avbvideosrc", 0,
+            "debug category for avbvideosrc element"));
+
+static void
+gst_avbvideosrc_class_init(GstAvbVideoSrcClass * klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+    GstElementClass *gstelement_class = GST_ELEMENT_CLASS(klass);
+    GstPushSrcClass *push_src_class = GST_PUSH_SRC_CLASS(klass);
+
+    /* Setting up pads and setting metadata should be moved to
+       base_class_init if you intend to subclass this class. */
+    gst_element_class_add_static_pad_template(GST_ELEMENT_CLASS(klass),
+            &gst_avbvideosrc_src_template);
+
+    gst_element_class_set_static_metadata(GST_ELEMENT_CLASS(klass),
+            "AVB-SH Source", "Source/Video/Network", "Retrieves MPEG-TS packets from AVB-SH",
+            "Intel");
+
+    gobject_class->finalize = gst_avbvideosrc_finalize;
+    gobject_class->set_property = gst_avbvideosrc_set_property;
+    gobject_class->get_property = gst_avbvideosrc_get_property;
+
+    gstelement_class->provide_clock = gst_avbvideosrc_provide_clock;
+    gstelement_class->change_state = gst_avbvideosrc_change_state;
+
+    push_src_class->create = GST_DEBUG_FUNCPTR(gst_avbvideosrc_create);
+
+    g_object_class_install_property(gobject_class, PROP_STREAM_NAME,
+            g_param_spec_string("stream-name", "Stream name",
+                "Name of the stream", DEFAULT_STREAM_NAME,
+                (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+}
+
+static void gst_avbvideosrc_set_property(GObject *object, guint prop_id,
+        const GValue *value, GParamSpec *pspec)
+{
+    GstAvbVideoSrc *avbvideosrc = GST_AVBVIDEOSRC(object);
+    (void)pspec;
+
+    if (prop_id == PROP_STREAM_NAME) {
+        free(avbvideosrc->stream_name);
+        avbvideosrc->stream_name = g_value_dup_string(value);
+        GST_DEBUG_OBJECT(avbvideosrc, "Set stream name to [%s]", avbvideosrc->stream_name);
+    }
+}
+
+static void gst_avbvideosrc_get_property(GObject *object, guint prop_id,
+        GValue *value, GParamSpec *pspec)
+{
+    GstAvbVideoSrc *avbvideosrc = GST_AVBVIDEOSRC(object);
+
+    if (prop_id == PROP_STREAM_NAME) {
+        g_value_set_string(value, avbvideosrc->stream_name);
+    } else {
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static GstStateChangeReturn
+gst_avbvideosrc_change_state(GstElement *element, GstStateChange transition)
+{
+    GstAvbVideoSrc *avbvideosrc = GST_AVBVIDEOSRC(element);
+    GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+
+    if (transition == GST_STATE_CHANGE_NULL_TO_READY) {
+        ias_avbvideobridge_result r;
+
+        avbvideosrc->receiver = ias_avbvideobridge_create_receiver("MpegTs_Receiver",
+                avbvideosrc->stream_name);
+        if (!avbvideosrc->receiver) {
+            GST_ERROR_OBJECT(avbvideosrc, "Could not create avbvideobridge receiver [%s]",
+                    avbvideosrc->stream_name);
+            return GST_STATE_CHANGE_FAILURE;
+        }
+        r = ias_avbvideobridge_register_MpegTS_cb(avbvideosrc->receiver,
+                &mpegts_callback, avbvideosrc);
+        if (r != IAS_AVB_RES_OK) {
+            GST_ERROR_OBJECT(avbvideosrc, "Could not register mpegts callback [%d]", r);
+            ias_avbvideobridge_destroy_receiver(avbvideosrc->receiver);
+            avbvideosrc->receiver = NULL;
+            return GST_STATE_CHANGE_FAILURE;
+        }
+    }
+
+    ret = GST_ELEMENT_CLASS(gst_avbvideosrc_parent_class)->change_state(element, transition);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+        if (transition == GST_STATE_CHANGE_NULL_TO_READY) {
+            ias_avbvideobridge_destroy_receiver(avbvideosrc->receiver);
+            avbvideosrc->receiver = NULL;
+        }
+        return ret;
+    }
+
+    if (transition == GST_STATE_CHANGE_PLAYING_TO_PAUSED) {
+        ret = GST_STATE_CHANGE_NO_PREROLL;
+        avbvideosrc->done = TRUE;
+    }
+
+    if (transition == GST_STATE_CHANGE_READY_TO_NULL) {
+        ias_avbvideobridge_destroy_receiver(avbvideosrc->receiver);
+        avbvideosrc->receiver = NULL;
+    }
+
+    return ret;
+}
+
+static void
+gst_avbvideosrc_init(GstAvbVideoSrc *avbvideosrc)
+{
+    gst_base_src_set_live(GST_BASE_SRC(avbvideosrc), TRUE);
+    gst_base_src_set_format(GST_BASE_SRC(avbvideosrc), GST_FORMAT_TIME);
+
+    avbvideosrc->queue = g_async_queue_new();
+    if (!avbvideosrc->queue) {
+        GST_ERROR_OBJECT(avbvideosrc, "Could not create async queue");
+        return;
+    }
+
+    GST_OBJECT_FLAG_SET(avbvideosrc, GST_ELEMENT_FLAG_PROVIDE_CLOCK);
+
+    avbvideosrc->stream_name = strdup(DEFAULT_STREAM_NAME);
+    avbvideosrc->done = FALSE;
+}
+
+void
+gst_avbvideosrc_finalize(GObject * object)
+{
+    GstAvbVideoSrc *avbvideosrc = GST_AVBVIDEOSRC(object);
+
+    // TODO use g_async_queue_unref_full to clean up any remaining items
+    g_async_queue_unref(avbvideosrc->queue);
+    avbvideosrc->queue = NULL;
+
+    free(avbvideosrc->stream_name);
+    avbvideosrc->stream_name = NULL;
+
+    G_OBJECT_CLASS(gst_avbvideosrc_parent_class)->finalize(object);
+}
+
+/* ask the subclass to create a buffer with offset and size, the default
+ * implementation will call alloc and fill. */
+static GstFlowReturn
+gst_avbvideosrc_create(GstPushSrc * src, GstBuffer ** buf)
+{
+    GstAvbVideoSrc *avbvideosrc = GST_AVBVIDEOSRC(src);
+
+    do {
+        *buf = (GstBuffer *)g_async_queue_timeout_pop(avbvideosrc->queue, 100000);
+    } while (*buf == NULL && !avbvideosrc->done);
+
+    return GST_FLOW_OK;
+}
+
+static GstClock *
+gst_avbvideosrc_provide_clock(GstElement *element)
+{
+    (void)element;
+
+    return gst_avbclock_obtain();
+}
+
+static void
+mpegts_callback(ias_avbvideobridge_receiver *receiver, bool sph, ias_avbvideobridge_buffer const * packet, void *user_ptr)
+{
+    GstAvbVideoSrc *avbvideosrc = GST_AVBVIDEOSRC(user_ptr);
+    unsigned int expected_size = sph ? MPEG_TS_PACKET_SIZE + SPH_SIZE : MPEG_TS_PACKET_SIZE;
+    unsigned int offset = sph ? SPH_SIZE : 0;
+    (void)receiver;
+
+    if ((packet->size % expected_size) != 0) {
+        GST_WARNING_OBJECT(avbvideosrc, "Packet may contain incomplete data. Size %zd is not a multiple of %u", packet->size, expected_size);
+    }
+
+    for (size_t j = 0; packet->size - j >= expected_size; j += expected_size) {
+        GstBuffer *buf;
+        guint8 *data = (guint8 *)packet->data;
+        GST_BASE_SRC_CLASS(gst_avbvideosrc_parent_class)->alloc(GST_BASE_SRC_CAST(avbvideosrc), -1, MPEG_TS_PACKET_SIZE, &buf);
+        GST_BUFFER_PTS(buf) = gst_avbclock_avtp_timestamp_to_pts(ntohl(*(unsigned*)(data + j)), GST_ELEMENT_CAST(avbvideosrc)->base_time);
+        gst_buffer_fill(buf, 0, data + j + offset, MPEG_TS_PACKET_SIZE);
+        g_async_queue_push(avbvideosrc->queue, buf);
+    }
+}


### PR DESCRIPTION
A simple gstreamer plugin interface to aid testing AVB-SH video features. Right now, it's only MPEG-TS compatible.

Note that this PR is against branch `next`, so that it can be merged without risks on `master`. When time is due, anything on `next` can go into `master`.