### PR TITLE
enabling AVBStreamHandler run as non-root user (RT-1137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ sudo chmod 660 /dev/igb_avb
 $ sudo chgrp ias_avb /dev/igb_avb
 $ sudo chmod 660 /dev/ptp*
 $ sudo chgrp ias_avb /dev/ptp*
-
+$ sudo chgrp ias_avb /dev/shm/igb_sem
 # Start the DLT daemon (for logging and tracing) #
 
 $ cd $AVB_DEPS/bin


### PR DESCRIPTION
Non-root can run the avb-stack by allowing the igb_avb to have permission for  /dev/shm/igb_sem 

sudo chgrp ias_avb /dev/shm/igb_sem

This step has to be added in the readme.md under the section "# Insert igb_avb kernel module #"  - https://github.com/intel/AVBStreamHandler#send-an-audio-stream-w-avbsh-demo
