### PR TITLE
Enable avb_streamhandler_demo in make install

### DIFF
--- a/CMakeLists.avb_configuration_reference.txt
+++ b/CMakeLists.avb_configuration_reference.txt
@@ -20,3 +20,5 @@ set_target_properties(ias-media_transport-avb_configuration_reference PROPERTIES
 if (${IAS_IS_HOST_BUILD})
   target_compile_options(ias-media_transport-avb_config_base PUBLIC -DIAS_HOST_BUILD=1)
 endif()
+
+install(TARGETS ias-media_transport-avb_configuration_reference DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.avb_streamhandler.txt
+++ b/CMakeLists.avb_streamhandler.txt
@@ -89,3 +89,5 @@ set_target_properties( ias-media_transport-avb_streamhandler PROPERTIES VERSION 
 target_link_libraries( ias-media_transport-avb_streamhandler ias-audio-common )
 target_link_libraries( ias-media_transport-avb_streamhandler ias-media_transport-lib_ptp_daemon )
 target_link_libraries( ias-media_transport-avb_streamhandler ias-media_transport-avb_helper )
+
+install(TARGETS ias-media_transport-avb_streamhandler DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.avb_streamhandler_demo.txt
+++ b/CMakeLists.avb_streamhandler_demo.txt
@@ -28,3 +28,8 @@ if (${IAS_IS_HOST_BUILD})
       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/setcap.sh $<TARGET_FILE:avb_streamhandler_demo>
   )
 endif()
+
+install(TARGETS avb_streamhandler_demo DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(CODE "execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/setcap.sh ${CMAKE_INSTALL_PREFIX}/bin/avb_streamhandler_demo)")
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 #------------------------------------------------------------------
 # avb_streamhandler main CMakeLists
 #------------------------------------------------------------------
-
+include(GNUInstallDirs)
 include( CMakeLists.lib_ptp_daemon.txt )
 include( CMakeLists.avb_helper.txt )
 include( CMakeLists.avb_streamhandler.txt )

--- a/setcap.sh
+++ b/setcap.sh
@@ -11,14 +11,19 @@
 if [ -x "$AVB_SETCAP_TOOL" ]; then
 	echo "Using setcap_tool defined on AVB_SETCAP_TOOL env var"
 	$AVB_SETCAP_TOOL $1 && exit
-	echo "Failed"
+	echo "Failed to set cap"
 fi
-
 which setcap_tool &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Trying to use setcap_tool on PATH env var"
 	setcap_tool $1 && exit
-	echo "Failed"
+	echo "Failed to set cap"
+fi
+which setcap &> /dev/null
+if [ $? -eq 0 ]; then
+	echo "running setcap on PATH env var"
+	setcap cap_net_admin,cap_net_raw,cap_sys_nice+ep $1 && exit
+	echo "Failed to set cap"
 fi
 
 echo "Warning: echo setcap_tool not installed"


### PR DESCRIPTION
1. add below lib and exe for make install
 /usr/lib64/libias-media_transport-avb_streamhandler.so
 /usr/lib64/pluginias-media_transport-avb_configuration_reference.so
 /usr/bin/avb_streamhandler_demo
2. setcap to /usr/bin/avb_streamhandler_demo
3. modify setcap.sh