### PR TITLE
Multi client

### DIFF
--- a/CMakeLists.avb_streamhandler.txt
+++ b/CMakeLists.avb_streamhandler.txt
@@ -44,6 +44,7 @@ add_library( ias-media_transport-avb_streamhandler SHARED
     private/src/avb_streamhandler/IasDiaLogger.cpp
     private/src/avb_streamhandler/IasAvbDiagnosticPacket.cpp
     private/src/avb_streamhandler/IasLocalAudioBufferDesc.cpp
+    private/src/avb_video_common/IasAvbVideoCondVar.cpp
     private/src/avb_video_common/IasAvbVideoShmConnection.cpp
     private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
     private/src/avb_video_common/IasAvbVideoRingBufferFactory.cpp

--- a/CMakeLists.avb_streamhandler.txt
+++ b/CMakeLists.avb_streamhandler.txt
@@ -45,6 +45,7 @@ add_library( ias-media_transport-avb_streamhandler SHARED
     private/src/avb_streamhandler/IasAvbDiagnosticPacket.cpp
     private/src/avb_streamhandler/IasLocalAudioBufferDesc.cpp
     private/src/avb_video_common/IasAvbVideoCondVar.cpp
+    private/src/avb_video_common/IasAvbVideoLog.cpp
     private/src/avb_video_common/IasAvbVideoShmConnection.cpp
     private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
     private/src/avb_video_common/IasAvbVideoRingBufferFactory.cpp

--- a/CMakeLists.avb_video_bridge.txt
+++ b/CMakeLists.avb_video_bridge.txt
@@ -13,6 +13,7 @@ add_library( ias-media_transport-avb_video_bridge STATIC
     private/src/avb_video_bridge/IasAvbVideoSender.cpp
     private/src/avb_video_bridge/IasAvbVideoReceiver.cpp
     private/src/avb_video_common/IasAvbVideoCondVar.cpp
+    private/src/avb_video_common/IasAvbVideoLog.cpp
     private/src/avb_video_common/IasAvbVideoShmConnection.cpp
     private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
     private/src/avb_video_common/IasAvbVideoRingBufferShm.cpp

--- a/CMakeLists.avb_video_bridge.txt
+++ b/CMakeLists.avb_video_bridge.txt
@@ -12,6 +12,7 @@ add_library( ias-media_transport-avb_video_bridge STATIC
     private/src/avb_video_bridge/IasAvbVideoBridge.cpp
     private/src/avb_video_bridge/IasAvbVideoSender.cpp
     private/src/avb_video_bridge/IasAvbVideoReceiver.cpp
+    private/src/avb_video_common/IasAvbVideoCondVar.cpp
     private/src/avb_video_common/IasAvbVideoShmConnection.cpp
     private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
     private/src/avb_video_common/IasAvbVideoRingBufferShm.cpp

--- a/private/inc/avb_streamhandler/IasAvbStreamHandlerEnvironment.hpp
+++ b/private/inc/avb_streamhandler/IasAvbStreamHandlerEnvironment.hpp
@@ -196,7 +196,7 @@ class IasAvbStreamHandlerEnvironment : private virtual IasAvbConfigRegistryInter
     static bool getConfigValue(const std::string &key, std::string &value);
     static bool doGetConfigValue(const std::string &key, uint64_t &value);
 
-    static DltContext &getDltContext(const std::string &dltContextName);
+    static __attribute__((weak)) DltContext &getDltContext(const std::string &dltContextName);
 
     static void notifySchedulingIssue(DltContext &dltContext, const std::string &text, const uint64_t elapsed,
                                       const uint64_t limit);

--- a/private/inc/avb_streamhandler/IasLocalVideoInStream.hpp
+++ b/private/inc/avb_streamhandler/IasLocalVideoInStream.hpp
@@ -96,9 +96,11 @@ class IasLocalVideoInStream : public IasLocalVideoStream, public IasIRunnable
     /*!
      * @brief copys the data form/to shared memory .
      *
+     * @param[in]  packet  thread-id of current thread
+     *
      * @returns  eIasAvbProcOK on success, otherwise an error code.
      */
-    IasAvbProcessingResult copyJob();
+    IasAvbProcessingResult copyJob(pid_t tid);
 
     /*!
      * @brief Returns whether the instance is initialized or not.

--- a/private/inc/avb_video_common/IasAvbVideoCondVar.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoCondVar.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file    IasAvbVideoCondVar.hpp
+ * @brief   Simple process sharing conditional variable.
+ * @details This condition variable uses futex directly, so it
+ *          doesn't hang if one of the waiter process suddenly crashes.
+ *
+ * @date    2018
+ */
+
+#ifndef IAS_MEDIATRANSPORT_VIDEOCOMMON_AVBVIDEOCONDVAR_HPP
+#define IAS_MEDIATRANSPORT_VIDEOCOMMON_AVBVIDEOCONDVAR_HPP
+
+#include <cstdint>
+
+#include <sys/time.h>
+
+namespace IasMediaTransportAvb {
+
+/**
+ * @brief A condition variable that can be shared among processes.
+ *
+ * It has some internal details (see CPP file for this class) that
+ * makes it unsuitable for any use cases different from IasAvbVideoRingBufferShm
+ * use cases.
+ */
+class IasAvbVideoCondVar {
+  public:
+
+    /**
+     * @brief The result type for the IasAvbVideoCondVar methods
+     */
+    enum IasResult
+    {
+      eIasOk,                         //!< Operation successful
+      eIasTimeout,                    //!< Timeout while waiting for condition variable
+      eIasCondWaitFailed,             //!< futex wait failed
+      eIasClockTimeNotAvailable,      //!< Clock time not available
+      eIasCondBroadcastFailed,        //!< futex broadcast failed
+    };
+
+    /**
+     * @brief Constructor
+     */
+    IasAvbVideoCondVar();
+
+    /**
+     * @brief Destructor
+     */
+    ~IasAvbVideoCondVar();
+
+    /**
+     * @brief Wait for the condition variable to be signaled for a certain time
+     *
+     * @param[in] time_ms timespan to wait at maximum for a condition variable
+     *
+     * @returns The status of the method call
+     * @retval eIasOk Condition variable was signaled before timeout
+     * @retval eIasTimeout Timeout while waiting for condition variable
+     * @retval eIasClockTimeNotAvailable Clock time not available
+     * @retval eIasCondWaitFailed Futex wait operation failed
+     */
+    IasResult wait(uint64_t time_ms);
+
+    /**
+     * @brief Broadcast the condition variable
+     *
+     * @returns The status of this call or the error that occurred during initialization
+     * @retval eIasOk Condition variable was signaled
+     * @retval eIasCondBroadcastFailed Futex broadcast failed
+     */
+    IasResult broadcast();
+
+  private:
+    /**
+     * @brief Copy constructor, private unimplemented to prevent misuse.
+     */
+    IasAvbVideoCondVar(IasAvbVideoCondVar const &other);
+
+    /**
+     * @brief Assignment operator, private unimplemented to prevent misuse.
+     */
+    IasAvbVideoCondVar& operator=(IasAvbVideoCondVar const &other);
+
+    /**
+     * @brief Wrapper for the futex system call
+     */
+    int futex(int *uaddr, int futex_op, int val,
+            const struct timespec *timeout, int *uaddr2, int val3);
+
+    int mFutex;  //!< The futex variable
+};
+
+}
+
+#endif

--- a/private/inc/avb_video_common/IasAvbVideoLog.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoLog.hpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file    IasAvbVideoLog.hpp
+ * @brief   Log "container" for AVB-SH Video Bridge.
+ * @details As AVB-SH Video Bridge has code that is shared with different
+ *          applications, it can not rely on IasAvbStreamHandlerEnvironment.
+ *          This class act as a "log multiplexer": if code is linked to
+ *          AVB-SH, it uses its log facilities, if not, will use another
+ *          that user provides.
+ *
+ * @date    2018
+ */
+
+#ifndef IAS_MEDIATRANSPORT_VIDEOCOMMON_AVBVIDEOLOG_HPP
+#define IAS_MEDIATRANSPORT_VIDEOCOMMON_AVBVIDEOLOG_HPP
+
+#include <string>
+
+#include <dlt/dlt.h>
+
+namespace IasMediaTransportAvb {
+
+/**
+ * @brief Provides log context for DLT log functions.
+ *
+ */
+class IasAvbVideoLog
+{
+  public:
+
+    /**
+     * @brief Get log context
+     *
+     * If application is linked to AVB-SH, it's a wrapper
+     * for IasAvbStreamHandlerEnvironment::getDltContext. If
+     * not, will ignore `dltContextName` parameter and return
+     * the DLT log context defined by the application. If
+     * application did not define a DLT context, will return
+     * a dummy one.
+     *
+     * @param[in] dltContextName Name of dlt log context
+     *
+     * @returns log context.
+     */
+    static DltContext &getDltContext(const std::string &dltContextName);
+
+    /**
+     * @brief Set log context for AVB-SH Video Bridge
+     *
+     * If application is not linked to AVB-SH, this method can
+     * be used to define a default DLT context for AVB-SH Video Bridge
+     * code.
+     *
+     * @param[in] dltContext DLT context to be used. If nullptr, remove any previously
+     * set context
+     */
+    static void setDltContext(DltContext *dltContext);
+
+  private:
+
+    static DltContext *mDefaultContext;     //!< Default context, set via setDltContext
+    static DltContext *mDltCtxDummy;        //!< Dummy context, if mDefaultContext is nullptr
+};
+
+}
+
+#endif

--- a/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
@@ -185,24 +185,6 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
     uint32_t getBufferSize() const;
 
     /*!
-     * @brief Reset the readOffset and the writeOffset to zero, so that the ring buffer appears to be empty.
-     *
-     * The function is intended to be called by the writer thread, while there is no write access in progress.
-     * The function applies a mutex, so that the readOffset is not modified while the reader thread reads
-     * from the buffer.
-     */
-    void resetFromWriter();
-
-    /*!
-     * @brief Reset the readOffset and the writeOffset to zero, so that the ring buffer will be empty again.
-     *
-     * The function is intended to be called by the reader thread, while there is no read access in progress.
-     * The function applies a mutex, so that the writeOffset is not modified while the writer thread writes
-     * into the buffer.
-     */
-    void resetFromReader();
-
-    /*!
      * @brief Set the name of the ring buffer.
      *
      * This function is called by the buffer factory to give the ring buffer a name.
@@ -217,17 +199,6 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      * @returns The name of the ring buffer
      */
     const std::string& getName() const { return mName; }
-
-    /*!
-     * @brief Overwrite current content with zeros
-     *
-     * This method overwrites the current content of the ring buffer with zeros.
-     * Note: It does NOT change the read or writer pointer or the buffer fill level, it only zeros out
-     * the content. This can be used in error situations, when a buffer is completely filled and we
-     * are not able to insert another packet. It would lead to playback of old vidoe frames when sometimes later
-     * the client tries to read out samples from the buffer.
-     */
-    void zeroOut();
 
     /*!
      * @brief Register a reader on the ringbuffer.

--- a/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
@@ -19,6 +19,7 @@
 #include "avb_video_common/IasAvbVideoCommonTypes.hpp"
 #include "avb_video_common/IasAvbVideoRingBufferResult.hpp"
 
+#include <dlt/dlt.h>
 
 namespace IasMediaTransportAvb {
 
@@ -51,6 +52,7 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      * @param[in]  dataBuf        The real data buffer
      * @param[in]  shared         Reserved for later use
      * @param[in]  ringBufShm     Pointer to the IasAvbVideoRingBufferShm
+     * @param[in]  dltContext     Log context
      *
      * @returns                   eIasRingBuffOk on success, otherwise an error code.
      */

--- a/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
@@ -83,11 +83,12 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      * entries to be written.
      *
      * @param[in]  access      Specifies the access type (either eIasRingBufferAccessRead or eIasRingBufferAccessWrite).
+     * @param[in]  pid         Caller pid. Must match a previous registered pid for read access. Ignored for write access.
      * @param[out] numBuffers  Returned number of buffers (packets) that are ready to be processed.
      *
      * @returns                eIasRingBuffOk on success, otherwise an error code.
      */
-    IasVideoRingBufferResult updateAvailable(IasRingBufferAccess access, uint32_t *numBuffers);
+    IasVideoRingBufferResult updateAvailable(IasRingBufferAccess access, pid_t pid, uint32_t *numBuffers);
 
     /*!
      * @brief Request to access the video ring buffer
@@ -98,6 +99,7 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      * buffer is full (playback) or empty (capture).
      *
      * @param[in]     access  Specifies the access type (either eIasRingBufferAccessRead or eIasRingBufferAccessWrite).
+     * @param[in]     pid     Caller pid. Must match a previous registered pid for read access. Ignored for write access.
      * @param[out]    dataPtr Returned mmap'ed base pointer to the data packets.
      * @param[out]    offset  Returned mmap offset in buffers (== packets).
      * @param[in,out] numBuffers  mmap area portion size in buffers (wanted on entry, contiguous available on exit).
@@ -105,6 +107,7 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      * @returns                eIasRingBuffOk on success, otherwise an error code.
      */
     IasVideoRingBufferResult beginAccess(IasRingBufferAccess access,
+                                         pid_t pid,
                                          void **dataPtr,
                                          uint32_t *offset,
                                          uint32_t *numBuffers);
@@ -121,24 +124,26 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      * IasAvbVideoRingBuffer::endAccess().
      *
      * @param[in] access  Specifies the access type (either eIasRingBufferAccessRead or eIasRingBufferAccessWrite).
+     * @param[in] pid     Caller pid. Must match a previous registered pid for read access. Ignored for write access.
      * @param[in] offset  Offset in buffers (== packets), must be equal to the offset value that
      *                    IasAvbVideoRingBuffer::beginAccess() returned.
      * @param[in] numBuffers  mmap area portion size in buffers (== number of packets that have been processed)
      *
      * @returns                eIasRingBuffOk on success, otherwise an error code.
      */
-    IasVideoRingBufferResult endAccess(IasRingBufferAccess access, uint32_t offset, uint32_t numBuffers);
+    IasVideoRingBufferResult endAccess(IasRingBufferAccess access, pid_t pid, uint32_t offset, uint32_t numBuffers);
 
     /*!
      * @brief function to read from ring buffer (with timeout) when a desired buffer level is reached.
      *        the function either returns when a timeout occurs or when the level is reached.
      *
+     * @param[in] pid         Caller pid. Must match a previous registered pid for read access.
      * @param[in] numBuffers  the desired buffer level, must be > 0 and >= total number of buffers
      * @param[in] timeout_ms  timeout in ms, function will return if buffer level is not reached within timeout, must be > 0
      *
      * @returns                eIasRingBuffOk on success, otherwise an error code.
      */
-    IasVideoRingBufferResult waitRead(uint32_t numBuffers, uint32_t timeout_ms);
+    IasVideoRingBufferResult waitRead(pid_t pid, uint32_t numBuffers, uint32_t timeout_ms);
 
     /*!
      * @brief function to write to ring buffer (with timeout) when a desired buffer level is reached.
@@ -221,6 +226,32 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      * the client tries to read out samples from the buffer.
      */
     void zeroOut();
+
+    /*!
+     * @brief Register a reader on the ringbuffer.
+     *
+     * As it's possible to have multiple readers reading a ringbuffer, it is necessary some
+     * coordination among them and the - single - writer. By registering a reader with the
+     * ringbuffer, ringbuffer becomes aware of that new reader, and can keep proper track of it.
+     * The id used here is expected on future beginAccess, endAccess and waitRead calls.
+     *
+     * @param[in] pid  An id for the reader - usually the thread id or process id for single thread readers.
+     *
+     * @returns        eIasRingBuffOk on success, otherwise an error code.
+     */
+    IasVideoRingBufferResult addReader(pid_t pid);
+
+    /*!
+     * @brief Unregister a reader on the ringbuffer.
+     *
+     * After this call, future beginAccess, endAccess and waitRead calls will fail with
+     * eIasRingBuffInvalidParam.
+     *
+     * @param[in] pid  Previously registered reader id.
+     *
+     * @returns        eIasRingBuffOk on success, otherwise an error code.
+     */
+    IasVideoRingBufferResult removeReader(pid_t pid);
 
   private:
     /*!

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferResult.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferResult.hpp
@@ -28,6 +28,7 @@ enum IasVideoRingBufferResult
   eIasRingBuffTimeOut,            //!< timeout exceeded
   eIasRingBuffProbeError,         //!< Probe error
   eIasRingBuffCondWaitFailed,     //!< Cond wait failed
+  eIasRingBuffTooManyReaders,     //!< Maximum readers limit exceeded
 };
 
 }

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
@@ -17,6 +17,7 @@
 #define IAS_MEDIATRANSPORT_VIDEOCOMMON_AVBVIDEORINGBUFFERSHM_HPP
 
 
+#include "avb_video_common/IasAvbVideoCondVar.hpp"
 #include "avb_video_common/IasAvbVideoCommonTypes.hpp"
 #include "avb_video_common/IasAvbVideoRingBufferResult.hpp"
 #include "internal/audio/common/IasIntProcCondVar.hpp"
@@ -311,8 +312,8 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
     IasIntProcMutex                       mMutex;                //!< used to lock critical sections
     IasIntProcMutex                       mMutexReadInProgress;  //!< to avoid that reset is executed while reading from buffer
     IasIntProcMutex                       mMutexWriteInProgress; //!< to avoid that reset is executed while writing into buffer
-    IasIntProcCondVar                     mCondRead;             //!< conditional variable for read access
-    IasIntProcCondVar                     mCondWrite;            //!< conditional variable for write access
+    IasAvbVideoCondVar                    mCondRead;             //!< conditional variable for read access
+    IasAvbVideoCondVar                    mCondWrite;            //!< conditional variable for write access
     uint32_t                              mReadWaitLevel;        //!< buffer level that must be reached before a signal is sent
     uint32_t                              mWriteWaitLevel;       //!< buffer level that must be reached before a signal is sent
 

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
@@ -176,35 +176,6 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
     uint32_t getWriteOffset() const { return mWriteOffset; }
 
     /*!
-     * @brief Reset the readOffset and the writeOffset to zero, so that the ring buffer appears to be empty.
-     *
-     * The function is intended to be called by the writer thread, while there is no write access in progress.
-     * The function applies a mutex, so that the readOffset is not modified while the reader thread reads
-     * from the buffer.
-     */
-    void resetFromWriter();
-
-    /*!
-     * @brief Reset the readOffset and the writeOffset to zero, so that the ring buffer will be empty again.
-     *
-     * The function is intended to be called by the reader thread, while there is no read access in progress.
-     * The function applies a mutex, so that the writeOffset is not modified while the writer thread writes
-     * into the buffer.
-     */
-    void resetFromReader();
-
-    /*!
-     * @brief Overwrite current content with zeros
-     *
-     * This method overwrites the current content of the ring buffer with zeros.
-     * Note: It does NOT change the read or writer pointer or the buffer fill level, it only zeros out
-     * the content. This can be used in error situations, when a buffer is completely filled and we
-     * are not able to insert another packet. It would lead to playback of old video frames when sometimes later
-     * the client tries to read out samples from the buffer.
-     */
-    void zeroOut();
-
-    /*!
      * @brief Register a reader on the ringbuffer.
      *
      * As it's possible to have multiple readers reading a ringbuffer, it is necessary some

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
@@ -31,6 +31,7 @@ using IasAudio::IasIntProcCondVar;
 
 namespace IasMediaTransportAvb {
 
+static const uint16_t cIasVideoRingBufferShmMaxReaders = 32;
 
 class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
 {
@@ -69,11 +70,12 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      * entries to be written.
      *
      * @param[in]  access      Specifies the access type (either eIasRingBufferAccessRead or eIasRingBufferAccessWrite).
+     * @param[in]  pid         Caller pid. Must match a previous registered pid for read access. Ignored for write access.
      * @param[out] numBuffers  Returned number of buffers (packets) that are ready to be processed.
      *
      * @returns                eIasRingBuffOk on success, otherwise an error code.
      */
-    IasVideoRingBufferResult updateAvailable(IasRingBufferAccess access, uint32_t *numBuffers);
+    IasVideoRingBufferResult updateAvailable(IasRingBufferAccess access, pid_t pid, uint32_t *numBuffers);
 
     /*!
      * @brief Request to access the video ring buffer
@@ -84,13 +86,14 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      * buffer is full (playback) or empty (capture).
      *
      * @param[in]     access  Specifies the access type (either eIasRingBufferAccessRead or eIasRingBufferAccessWrite).
+     * @param[in]     pid     Caller pid. Must match a previous registered pid for read access. Ignored for write access.
      * @param[out]    dataPtr Returned mmap'ed base pointer to the data packets.
      * @param[out]    offset  Returned mmap offset in buffers (== packets).
      * @param[in,out] numBuffers  mmap area portion size in buffers (wanted on entry, contiguous available on exit).
      *
      * @returns                eIasRingBuffOk on success, otherwise an error code.
      */
-    IasVideoRingBufferResult beginAccess(IasRingBufferAccess access, uint32_t* offset, uint32_t* numBuffers);
+    IasVideoRingBufferResult beginAccess(IasRingBufferAccess access, pid_t pid, uint32_t* offset, uint32_t* numBuffers);
 
     /*!
      * @brief Declare that accessing a portion of an mmap'ed area has finished.
@@ -104,13 +107,14 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      * IasAvbVideoRingBuffer::endAccess().
      *
      * @param[in] access  Specifies the access type (either eIasRingBufferAccessRead or eIasRingBufferAccessWrite).
+     * @param[in] pid     Caller pid. Must match a previous registered pid for read access. Ignored for write access.
      * @param[in] offset  Offset in buffers (== packets), must be equal to the offset value that
      *                    IasAvbVideoRingBuffer::beginAccess() returned.
      * @param[in] numBuffers  mmap area portion size in buffers (== number of packets that have been processed)
      *
      * @returns           eIasRingBuffOk on success, otherwise an error code.
      */
-    IasVideoRingBufferResult endAccess(IasRingBufferAccess access, uint32_t offset, uint32_t numBuffers);
+    IasVideoRingBufferResult endAccess(IasRingBufferAccess access, pid_t pid, uint32_t offset, uint32_t numBuffers);
 
     /*!
      * @brief function to retrieve the data pointer.
@@ -137,12 +141,13 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      * @brief function to read from ring buffer (with timeout) when a desired buffer level is reached.
      *        the function either returns when a timeout occurs or when the level is reached.
      *
+     * @param[in] pid         Caller pid. Must match a previous registered pid for read access.
      * @param[in] numBuffers  the desired buffer level, must be > 0 and >= total number of buffers
      * @param[in] timeout_ms  timeout in ms, function will return if buffer level is not reached within timeout, must be > 0
      *
      * @returns               eIasRingBuffOk on success, otherwise an error code.
      */
-    IasVideoRingBufferResult waitRead(uint32_t numBuffers, uint32_t timeout_ms);
+    IasVideoRingBufferResult waitRead(pid_t pid, uint32_t numBuffers, uint32_t timeout_ms);
 
     /*!
      * @brief function to write to ring buffer (with timeout) when a desired buffer level is reached.
@@ -196,7 +201,39 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      */
     void zeroOut();
 
+    /*!
+     * @brief Register a reader on the ringbuffer.
+     *
+     * As it's possible to have multiple readers reading a ringbuffer, it is necessary some
+     * coordination among them and the - single - writer. By registering a reader with the
+     * ringbuffer, ringbuffer becomes aware of that new reader, and can keep proper track of it.
+     * The id used here is expected on future beginAccess, endAccess and waitRead calls.
+     *
+     * @param[in] pid  An id for the reader - usually the thread id or process id for single thread readers.
+     *
+     * @returns        eIasRingBuffOk on success, otherwise an error code.
+     */
+    IasVideoRingBufferResult addReader(pid_t pid);
+
+    /*!
+     * @brief Unregister a reader on the ringbuffer.
+     *
+     * After this call, future beginAccess, endAccess and waitRead calls will fail with
+     * eIasRingBuffInvalidParam.
+     *
+     * @param[in] pid  Previously registered reader id.
+     *
+     * @returns        eIasRingBuffOk on success, otherwise an error code.
+     */
+    IasVideoRingBufferResult removeReader(pid_t pid);
+
   private:
+
+    /* Struct to keep track of reader register to read on this RingBuffer */
+    struct RingBufferReader {
+        pid_t pid;
+        uint32_t offset;
+    };
 
     /*!
      * @brief Copy constructor, private unimplemented to prevent misuse.
@@ -208,6 +245,54 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      */
     IasAvbVideoRingBufferShm& operator=(IasAvbVideoRingBufferShm const &other);
 
+    /*!
+     * @brief Get smaller reader offset and resets readers offset when due
+     *
+     * Walks readers list and get which one has the smallest offset - or, the
+     * offset of the slowest reader. Also, if all readers are at the end of
+     * the buffer, resets their offsets, so they can start reading from the
+     * beginning again.
+     *
+     * @returns        smallest offset of all readers, or UINT32_MAX if no readers are registered.
+     */
+    uint32_t updateSmallerReaderOffset();
+
+    /*!
+     * @brief updates mReadOffset with smallest offset among readers
+     *
+     * This helps ringbuffer to keep track of what packets weren't read yet.
+     */
+    void aggregateReaderOffset();
+
+    /*!
+     * @brief Get individual reader buffer level
+     *
+     * As some readers may be faster than others, the buffer level (i.e., how many packets
+     * were not read) will vary from reader to reader. This method calculates the right
+     * buffer level for any reader.
+     *
+     * @returns     reader buffer level.
+     */
+    uint32_t calculateReaderBufferLevel(RingBufferReader *reader);
+
+    /*!
+     * @brief Returns a RingBufferReader entry for a reader, given its id
+     *
+     * @returns     reader or nullptr if no reader with given id was found.
+     */
+    RingBufferReader *findReader(pid_t pid) {
+      if (pid > 0)
+      {
+        for (int i = 0; i < cIasVideoRingBufferShmMaxReaders; i++)
+        {
+          if (mReaders[i].pid == pid)
+          {
+            return &mReaders[i];
+          }
+        }
+      }
+      return nullptr;
+    };
 
     //
     // Member variables
@@ -230,6 +315,9 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
     IasIntProcCondVar                     mCondWrite;            //!< conditional variable for write access
     uint32_t                              mReadWaitLevel;        //!< buffer level that must be reached before a signal is sent
     uint32_t                              mWriteWaitLevel;       //!< buffer level that must be reached before a signal is sent
+
+    IasIntProcMutex                       mMutexReaders;                              //!< Protects access to mReaders array
+    RingBufferReader                      mReaders[cIasVideoRingBufferShmMaxReaders]; //!< List of active readers
 };
 
 } // namespace IasMediaTransportAvb

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
@@ -234,6 +234,7 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
     struct RingBufferReader {
         pid_t pid;
         uint32_t offset;
+        uint32_t allowedToRead;
         std::atomic<uint64_t> lastAccess;
     };
 
@@ -327,6 +328,7 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
     IasAvbVideoCondVar                    mCondWrite;            //!< conditional variable for write access
     uint32_t                              mReadWaitLevel;        //!< buffer level that must be reached before a signal is sent
     uint32_t                              mWriteWaitLevel;       //!< buffer level that must be reached before a signal is sent
+    uint32_t                              mAllowedToWrite;       //!< how many buffers (packets) were allowed to writer on last beginAccess
 
     IasIntProcMutex                       mMutexReaders;                              //!< Protects access to mReaders array
     RingBufferReader                      mReaders[cIasVideoRingBufferShmMaxReaders]; //!< List of active readers

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
@@ -234,6 +234,7 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
     struct RingBufferReader {
         pid_t pid;
         uint32_t offset;
+        std::atomic<uint64_t> lastAccess;
     };
 
     /*!
@@ -275,6 +276,16 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      * @returns     reader buffer level.
      */
     uint32_t calculateReaderBufferLevel(RingBufferReader *reader);
+
+    /*!
+     * @brief updates lastAccess for reader, so it's possible to track reader death by timeout
+     */
+    void updateReaderAccess(RingBufferReader *reader);
+
+    /*!
+     * @brief Removes any reader whose lastAccess is bigger than a defined threshold (a presumably dead reader).
+     */
+    void purgeUnresponsiveReaders();
 
     /*!
      * @brief Returns a RingBufferReader entry for a reader, given its id

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
@@ -18,6 +18,7 @@
 
 
 #include "avb_video_common/IasAvbVideoCondVar.hpp"
+#include "avb_video_common/IasAvbVideoLog.hpp"
 #include "avb_video_common/IasAvbVideoCommonTypes.hpp"
 #include "avb_video_common/IasAvbVideoRingBufferResult.hpp"
 #include "internal/audio/common/IasIntProcCondVar.hpp"
@@ -25,6 +26,7 @@
 
 #include <atomic>
 #include <boost/interprocess/offset_ptr.hpp>
+#include <dlt/dlt.h>
 
 // Using mutex and condvar from audio/common
 using IasAudio::IasIntProcMutex;
@@ -306,6 +308,13 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
       }
       return nullptr;
     };
+
+    /* As this class lives on shared memory, it can *not* save anything that
+     * is related to any process, like the log context. It needs to get it every
+     * time, so to get the right log context for the calling process */
+    DltContext &getLogContext() {
+        return IasAvbVideoLog::getDltContext("_RBF");
+    }
 
     //
     // Member variables

--- a/private/inc/gst/gstavbvideosrc.h
+++ b/private/inc/gst/gstavbvideosrc.h
@@ -8,6 +8,8 @@
 
 #include <gst/base/gstpushsrc.h>
 
+#include <dlt/dlt.h>
+
 #include "media_transport/avb_video_bridge/IasAvbVideoBridge.h"
 
 G_BEGIN_DECLS
@@ -24,6 +26,8 @@ typedef struct _GstAvbVideoSrcClass GstAvbVideoSrcClass;
 struct _GstAvbVideoSrc
 {
     GstPushSrc base_avbvideosrc;
+
+    DltContext log;
 
     struct ias_avbvideobridge_receiver *receiver;
     GAsyncQueue *queue;

--- a/private/src/avb_streamhandler/IasLocalVideoOutStream.cpp
+++ b/private/src/avb_streamhandler/IasLocalVideoOutStream.cpp
@@ -207,7 +207,7 @@ IasAvbProcessingResult IasLocalVideoOutStream::pushPayload(PacketH264 const & pa
     void *basePtr = nullptr;
     uint32_t numPacketsTransferred = 0u;
 
-    if (ringBuffer->beginAccess(eIasRingBufferAccessWrite, &basePtr, &offset, &numPackets))  // numPackets returned here is the overall numbers of packets available for read or write, but not more than requested
+    if (ringBuffer->beginAccess(eIasRingBufferAccessWrite, getpid(), &basePtr, &offset, &numPackets))  // numPackets returned here is the overall numbers of packets available for read or write, but not more than requested
     {
       // this could happen if multiple threads concurrently access the ring buffer in the same direction
       DLT_LOG_CXX(*mLog, DLT_LOG_WARN, LOG_PREFIX, "error in beginAccess of ring buffer");
@@ -231,7 +231,7 @@ IasAvbProcessingResult IasLocalVideoOutStream::pushPayload(PacketH264 const & pa
         numPacketsTransferred++;
       }
 
-      if (ringBuffer->endAccess(eIasRingBufferAccessWrite, offset, numPacketsTransferred))
+      if (ringBuffer->endAccess(eIasRingBufferAccessWrite, getpid(), offset, numPacketsTransferred))
       {
         DLT_LOG_CXX(*mLog, DLT_LOG_ERROR, LOG_PREFIX, "error in endAccess of sink ring buffer");
         result = eIasAvbProcErr;
@@ -266,7 +266,7 @@ IasAvbProcessingResult IasLocalVideoOutStream::pushPayload(PacketMpegTS const & 
     void *basePtr = nullptr;
     uint32_t numPacketsTransferred = 0u;
 
-    if (ringBuffer->beginAccess(eIasRingBufferAccessWrite, &basePtr, &offset, &numPackets))  // numPackets returned here is the overall numbers of packets available for read or write, but not more than requested
+    if (ringBuffer->beginAccess(eIasRingBufferAccessWrite, getpid(), &basePtr, &offset, &numPackets))  // numPackets returned here is the overall numbers of packets available for read or write, but not more than requested
     {
       // this could happen if multiple threads concurrently access the ring buffer in the same direction
       DLT_LOG_CXX(*mLog, DLT_LOG_WARN, LOG_PREFIX, "error in beginAccess of ring buffer");
@@ -291,7 +291,7 @@ IasAvbProcessingResult IasLocalVideoOutStream::pushPayload(PacketMpegTS const & 
         numPacketsTransferred++;
       }
 
-      if (ringBuffer->endAccess(eIasRingBufferAccessWrite, offset, numPacketsTransferred))
+      if (ringBuffer->endAccess(eIasRingBufferAccessWrite, getpid(), offset, numPacketsTransferred))
       {
         DLT_LOG_CXX(*mLog, DLT_LOG_ERROR, LOG_PREFIX, "error in endAccess of sink ring buffer");
         result = eIasAvbProcErr;

--- a/private/src/avb_video_bridge/IasAvbVideoBridge.cpp
+++ b/private/src/avb_video_bridge/IasAvbVideoBridge.cpp
@@ -12,9 +12,9 @@
 
 #include "avb_helper/ias_visibility.h"
 #include "media_transport/avb_video_bridge/IasAvbVideoBridge.h"
+#include "avb_video_common/IasAvbVideoLog.hpp"
 #include "avb_video_bridge/IasAvbVideoSender.hpp"
 #include "avb_video_bridge/IasAvbVideoReceiver.hpp"
-
 
 namespace IasMediaTransportAvb {
 
@@ -24,6 +24,10 @@ extern "C"
 {
 #endif
 
+IAS_DSO_PUBLIC void ias_avbvideobridge_register_log_context(DltContext *dlt_context)
+{
+    IasAvbVideoLog::setDltContext(dlt_context);
+}
 
 IAS_DSO_PUBLIC ias_avbvideobridge_sender* ias_avbvideobridge_create_sender(const char* senderRole)
 {

--- a/private/src/avb_video_bridge/IasAvbVideoSender.cpp
+++ b/private/src/avb_video_bridge/IasAvbVideoSender.cpp
@@ -92,10 +92,10 @@ ias_avbvideobridge_result IasAvbVideoSender::sendPacketH264(ias_avbvideobridge_b
     }
     else
     {
-      IasVideoRingBufferResult result = mRingBuffer->beginAccess(eIasRingBufferAccessWrite, &basePtr, &offset, &numPackets);
+      IasVideoRingBufferResult result = mRingBuffer->beginAccess(eIasRingBufferAccessWrite, getpid(), &basePtr, &offset, &numPackets);
       if (eIasRingBuffOk != result)
       {
-        (void) mRingBuffer->endAccess(eIasRingBufferAccessWrite, offset, numPacketsTransferred);
+        (void) mRingBuffer->endAccess(eIasRingBufferAccessWrite, getpid(), offset, numPacketsTransferred);
         res = IAS_AVB_RES_NO_SPACE;
       }
       else
@@ -111,7 +111,7 @@ ias_avbvideobridge_result IasAvbVideoSender::sendPacketH264(ias_avbvideobridge_b
           numPacketsTransferred++;
         }
 
-        if (mRingBuffer->endAccess(eIasRingBufferAccessWrite, offset, numPacketsTransferred))
+        if (mRingBuffer->endAccess(eIasRingBufferAccessWrite, getpid(), offset, numPacketsTransferred))
         {
           res = IAS_AVB_RES_FAILED;
         }
@@ -146,10 +146,10 @@ ias_avbvideobridge_result IasAvbVideoSender::sendPacketMpegTs(bool sph, ias_avbv
     }
     else
     {
-      IasVideoRingBufferResult result = mRingBuffer->beginAccess(eIasRingBufferAccessWrite, &basePtr, &offset, &numPackets);
+      IasVideoRingBufferResult result = mRingBuffer->beginAccess(eIasRingBufferAccessWrite, getpid(), &basePtr, &offset, &numPackets);
       if (eIasRingBuffOk != result)
       {
-        (void) mRingBuffer->endAccess(eIasRingBufferAccessWrite, offset, numPacketsTransferred);
+        (void) mRingBuffer->endAccess(eIasRingBufferAccessWrite, getpid(), offset, numPacketsTransferred);
         res = IAS_AVB_RES_NO_SPACE;
       }
       else
@@ -166,7 +166,7 @@ ias_avbvideobridge_result IasAvbVideoSender::sendPacketMpegTs(bool sph, ias_avbv
           numPacketsTransferred++;
         }
 
-        if (mRingBuffer->endAccess(eIasRingBufferAccessWrite, offset, numPacketsTransferred))
+        if (mRingBuffer->endAccess(eIasRingBufferAccessWrite, getpid(), offset, numPacketsTransferred))
         {
           return IAS_AVB_RES_FAILED;
         }

--- a/private/src/avb_video_common/IasAvbVideoCondVar.cpp
+++ b/private/src/avb_video_common/IasAvbVideoCondVar.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "avb_video_common/IasAvbVideoCondVar.hpp"
+
+#include <cerrno>
+#include <climits>
+#include <iostream>
+
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define MSEC_PER_SEC 1000
+#define NSEC_PER_SEC 1000000000
+#define NSEC_PER_MSEC 1000000
+
+namespace IasMediaTransportAvb {
+
+#define TIMESPEC_TO_MSEC(ts) ((ts.tv_sec * MSEC_PER_SEC) + (ts.tv_nsec / NSEC_PER_MSEC))
+
+IasAvbVideoCondVar::IasAvbVideoCondVar()
+    :mFutex(0)
+{
+  // Nothing to do?
+}
+
+IasAvbVideoCondVar::~IasAvbVideoCondVar()
+{
+  // Could we check if there's someone waiting? Should we send a broadcast here?
+}
+
+/**
+ * Some notes about futex usage in this class.
+ *
+ * Usually a futex - as fast userspace mutex - will have a varying value, but
+ * in this class one can notice that mFutex is always 0.
+ *
+ * IasAvbVideoCondVar provides for a very specific use case: multiple readers,
+ * that can read together from a ringbuffer, as long as there is something to read.
+ * "As long as there is something to read" is verified on IasAvbVideoRingBufferShm
+ * class `waitRead` method. If this predicate is true, there will be no wait. When
+ * it is false (so there's nothing to read) the thread/process will wait. The writter
+ * process is the one who adds things to the ringbuffer, so it's the one who can
+ * change this predicate. When it does so, it issues a `broadcast` on the condition
+ * variable, to awake all readers that were waiting. So, the truth value of the
+ * predicate is controlled by IasAvbVideoRingBufferShm, and the futex here is only
+ * used to keep a list of threads/process waiting and wake them up when needed.
+ *
+ * In the end, the value of the mutex is not important in this use case - setting it
+ * to any value to replicate predicate truth value is unnecessary.
+ *
+ * Race conditions
+ *
+ * One can argue that this simple approach is prone to race conditions: what if a thread
+ * decides to wait and before actually sleeping the writer sends a broadcast, so reader
+ * starts to wait but the broadcast was lost?
+ *
+ * That's a valid concern. This class could then use different values for mFutex to
+ * have some control over this. For instance, `broadcast` could set it to "1", so
+ * that a reader would only sleep if the mFutex value is not "1". While this is a simple
+ * solution, it adds new problems: who sets the value to "0"? The first thread trying
+ * to wait? If so, it will always find it as "1", not sleep just to find out that the
+ * predicate didn't change, then sleep. If first thread to awake takes this task,
+ * we can still risk a third thread going to sleep unnecessarily if it was blocked after
+ * checking the predicate and unblocked after first thread change value to "0".
+ *
+ * A simple approach is that no thread can wait forever, but only for a certain time.
+ * This way, even if it goes to sleep unnecessarily, it will soon awake due timeout,
+ * and all code dealing with the ringbuffer simply accepts that timeout is not an issue,
+ * unless it happens many times. This simpler approach is the one used by this class.
+ *
+ * Naturally, if the race condition case become so common that affects performance,
+ * it's possible to revisit this class and add some code to squeeze the probability of
+ * it happening.
+ *
+ * Finally, note that the way ringbuffer works prevent the case in which a reader
+ * decides to sleep and writer sends broadcast just before reader actually sleeps
+ * happening twice: after the reader awakes on timeout, predicate will still be
+ * true, as ringbuffer waits all readers to read.
+ *
+ * Mutex for the condition variable
+ *
+ * POSIX threads condition variables require a mutex to work with, but this class
+ * does not. As one of the goals of this condition variable is to awake all readers
+ * and all of them can read the ringbuffer at the same time, requiring a mutex would
+ * defeat this purpose.
+ *
+ * Writer also uses this condition variable
+ *
+ * IasAvbVideoRingBufferShm class also uses a IasAvbVideoCondVar for the writer. The
+ * reason is to avoid keeping more than one implementation of condition variables,
+ * with different idiosyncrasies. For instance, the need for a mutex for POSIX
+ * condition variables.
+ *
+ * General case
+ *
+ * As previous comments note, this condition variable is not generic and may not
+ * fit different use cases (or even IasAvbVideoRingBufferShm if it changes).
+ */
+IasAvbVideoCondVar::IasResult IasAvbVideoCondVar::wait(uint64_t time_ms)
+{
+  struct timespec ts;
+  uint64_t enter_time;
+  IasResult result = eIasOk;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
+    return eIasClockTimeNotAvailable;
+  }
+  enter_time = TIMESPEC_TO_MSEC(ts);
+
+  ts.tv_sec = time_ms / MSEC_PER_SEC;
+  ts.tv_nsec = (time_ms % MSEC_PER_SEC) * NSEC_PER_MSEC;
+
+  while (true)
+  {
+    int ret = futex(&mFutex, FUTEX_WAIT, 0, &ts, NULL, 0);
+    if (ret == 0)
+    {
+      break;
+    }
+    else if (errno == EINTR)
+    {
+      // How much time has passed?
+      if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
+          result = eIasClockTimeNotAvailable;
+      }
+      else
+      {
+        uint64_t elapsed_time = TIMESPEC_TO_MSEC(ts) - enter_time;
+        if (elapsed_time > time_ms)
+        {
+          // Ok, we were interrupted, but it was about time
+          break;
+        }
+        else
+        {
+          // Wait again, but for remaining time only
+          time_ms = time_ms - elapsed_time;
+
+          ts.tv_sec = time_ms / MSEC_PER_SEC;
+          ts.tv_nsec = (time_ms % MSEC_PER_SEC) * NSEC_PER_MSEC;
+          continue;
+        }
+      }
+    }
+    else if (errno == ETIMEDOUT)
+    {
+      result = eIasTimeout;
+      break;
+    }
+    else
+    {
+      result = eIasCondWaitFailed;
+      break;
+    }
+  }
+
+  return result;
+}
+
+IasAvbVideoCondVar::IasResult IasAvbVideoCondVar::broadcast()
+{
+  int ret;
+  IasResult result = eIasOk;
+
+  ret = futex(&mFutex, FUTEX_WAKE, INT_MAX, NULL, NULL, 0);
+
+  if (ret == -1)
+  {
+    result = eIasCondBroadcastFailed;
+  }
+
+  return result;
+}
+
+int IasAvbVideoCondVar::futex(int *uaddr, int futex_op, int val,
+    const struct timespec *timeout, int *uaddr2, int val3)
+{
+  return (int)syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr2, val3);
+}
+
+}

--- a/private/src/avb_video_common/IasAvbVideoLog.cpp
+++ b/private/src/avb_video_common/IasAvbVideoLog.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "avb_video_common/IasAvbVideoLog.hpp"
+#include "avb_streamhandler/IasAvbStreamHandlerEnvironment.hpp"
+
+#include <dlt/dlt_cpp_extension.hpp>
+
+namespace IasMediaTransportAvb {
+
+static const std::string cClassName = "IasAvbVideoLog::";
+#define LOG_PREFIX cClassName + __func__ + "(" + std::to_string(__LINE__) + "):"
+
+DltContext *IasAvbVideoLog::mDltCtxDummy = NULL;
+DltContext *IasAvbVideoLog::mDefaultContext = NULL;
+
+DltContext &IasAvbVideoLog::getDltContext(const std::string &dltContextName)
+{
+
+  if (IasAvbStreamHandlerEnvironment::getDltContext)
+  {
+    return IasAvbStreamHandlerEnvironment::getDltContext(dltContextName);
+  }
+
+  if (mDefaultContext != nullptr)
+  {
+    return *mDefaultContext;
+  }
+
+  if (mDltCtxDummy == nullptr)
+  {
+    mDltCtxDummy = new DltContext();
+    DLT_REGISTER_CONTEXT_LL_TS(*mDltCtxDummy, "_DMY", "context not found, creating dummy one", DLT_LOG_INFO,
+                                 DLT_TRACE_STATUS_OFF);
+    DLT_LOG_CXX(*mDltCtxDummy, DLT_LOG_WARN, LOG_PREFIX, "Context", dltContextName, "not found, creating dummy one");
+  }
+
+  return *mDltCtxDummy;
+}
+
+void IasAvbVideoLog::setDltContext(DltContext *dltContext)
+{
+  if (mDefaultContext != nullptr)
+  {
+    DLT_LOG_CXX(*mDefaultContext, DLT_LOG_WARN, LOG_PREFIX, "Replacing AVB Video Bridge default log context");
+  }
+
+  mDefaultContext = dltContext;
+
+  if (mDefaultContext != nullptr)
+  {
+    DLT_LOG_CXX(*mDefaultContext, DLT_LOG_WARN, LOG_PREFIX, "Set new AVB Video Bridge default log context");
+  }
+}
+
+}

--- a/private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
+++ b/private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
@@ -281,45 +281,6 @@ uint32_t IasAvbVideoRingBuffer::getBufferSize() const
   return result;
 }
 
-
-void IasAvbVideoRingBuffer::resetFromWriter()
-{
-  if (nullptr == mRingBufShm)
-  {
-    AVB_ASSERT(false);
-  }
-  else if (mIsShm)
-  {
-    mRingBufShm->resetFromWriter();
-  }
-}
-
-
-void IasAvbVideoRingBuffer::resetFromReader()
-{
-  if (nullptr == mRingBufShm)
-  {
-    AVB_ASSERT(false);
-  }
-  else if (mIsShm)
-  {
-    mRingBufShm->resetFromReader();
-  }
-}
-
-
-void IasAvbVideoRingBuffer::zeroOut()
-{
-  if (nullptr == mRingBufShm)
-  {
-    AVB_ASSERT(false);
-  }
-  else if (mIsShm)
-  {
-    mRingBufShm->zeroOut();
-  }
-}
-
 IasVideoRingBufferResult IasAvbVideoRingBuffer::addReader(pid_t pid)
 {
   if (nullptr == mRingBufShm)

--- a/private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
+++ b/private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
@@ -98,7 +98,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::setup(IasAvbVideoRingBufferShm* 
 }
 
 
-IasVideoRingBufferResult IasAvbVideoRingBuffer::updateAvailable(IasRingBufferAccess access, uint32_t* numBuffers)
+IasVideoRingBufferResult IasAvbVideoRingBuffer::updateAvailable(IasRingBufferAccess access, pid_t pid, uint32_t* numBuffers)
 {
   IasVideoRingBufferResult result = eIasRingBuffOk;
 
@@ -112,7 +112,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::updateAvailable(IasRingBufferAcc
   }
   else if (mIsShm)
   {
-    result = mRingBufShm->updateAvailable(access, numBuffers);
+    result = mRingBufShm->updateAvailable(access, pid, numBuffers);
   }
   else
   {
@@ -123,7 +123,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::updateAvailable(IasRingBufferAcc
 }
 
 
-IasVideoRingBufferResult IasAvbVideoRingBuffer::beginAccess(IasRingBufferAccess access, void **dataPtr, uint32_t* offset, uint32_t* numBuffers)
+IasVideoRingBufferResult IasAvbVideoRingBuffer::beginAccess(IasRingBufferAccess access, pid_t pid, void **dataPtr, uint32_t* offset, uint32_t* numBuffers)
 {
   IasVideoRingBufferResult result = eIasRingBuffOk;
 
@@ -138,7 +138,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::beginAccess(IasRingBufferAccess 
   else if (mIsShm)
   {
     *dataPtr = mDataPtr;
-    result = mRingBufShm->beginAccess(access, offset, numBuffers);
+    result = mRingBufShm->beginAccess(access, pid, offset, numBuffers);
   }
   else
   {
@@ -149,7 +149,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::beginAccess(IasRingBufferAccess 
 }
 
 
-IasVideoRingBufferResult IasAvbVideoRingBuffer::endAccess(IasRingBufferAccess access, uint32_t offset, uint32_t numBuffers)
+IasVideoRingBufferResult IasAvbVideoRingBuffer::endAccess(IasRingBufferAccess access, pid_t pid, uint32_t offset, uint32_t numBuffers)
 {
   IasVideoRingBufferResult result = eIasRingBuffOk;
 
@@ -163,7 +163,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::endAccess(IasRingBufferAccess ac
   }
   else if (mIsShm)
   {
-    result = mRingBufShm->endAccess(access, offset, numBuffers);
+    result = mRingBufShm->endAccess(access, pid, offset, numBuffers);
   }
   else
   {
@@ -174,7 +174,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::endAccess(IasRingBufferAccess ac
 }
 
 
-IasVideoRingBufferResult IasAvbVideoRingBuffer::waitRead(uint32_t numBuffers, uint32_t timeout_ms)
+IasVideoRingBufferResult IasAvbVideoRingBuffer::waitRead(pid_t pid, uint32_t numBuffers, uint32_t timeout_ms)
 {
   IasVideoRingBufferResult result = eIasRingBuffOk;
 
@@ -184,7 +184,7 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::waitRead(uint32_t numBuffers, ui
   }
   else if (mIsShm)
   {
-    result = mRingBufShm->waitRead(numBuffers, timeout_ms);
+    result = mRingBufShm->waitRead(pid, numBuffers, timeout_ms);
   }
   else
   {
@@ -318,6 +318,34 @@ void IasAvbVideoRingBuffer::zeroOut()
   {
     mRingBufShm->zeroOut();
   }
+}
+
+IasVideoRingBufferResult IasAvbVideoRingBuffer::addReader(pid_t pid)
+{
+  if (nullptr == mRingBufShm)
+  {
+    AVB_ASSERT(false);
+  }
+  else if (mIsShm)
+  {
+    return mRingBufShm->addReader(pid);
+  }
+
+  return eIasRingBuffNotAllowed;
+}
+
+IasVideoRingBufferResult IasAvbVideoRingBuffer::removeReader(pid_t pid)
+{
+  if (nullptr == mRingBufShm)
+  {
+    AVB_ASSERT(false);
+  }
+  else if (mIsShm)
+  {
+    return mRingBufShm->removeReader(pid);
+  }
+
+  return eIasRingBuffNotAllowed;
 }
 
 } // namespace IasMediaTransportAvb

--- a/private/src/avb_video_common/IasAvbVideoRingBufferFactory.cpp
+++ b/private/src/avb_video_common/IasAvbVideoRingBufferFactory.cpp
@@ -12,10 +12,10 @@
  */
 
 #include "audio/common/audiobuffer/IasMemoryAllocator.hpp"
+#include "avb_video_common/IasAvbVideoLog.hpp"
 #include "avb_video_common/IasAvbVideoRingBufferFactory.hpp"
 #include "avb_video_common/IasAvbVideoRingBuffer.hpp"
 #include "avb_video_common/IasAvbVideoRingBufferShm.hpp"
-#include "avb_streamhandler/IasAvbStreamHandlerEnvironment.hpp"
 
 #include <dlt/dlt_cpp_extension.hpp>
 
@@ -23,7 +23,6 @@ using IasAudio::IasMemoryAllocator;
 
 
 namespace IasMediaTransportAvb {
-
 
 static const std::string cClassName = "IasAvbVideoRingBufferFactory::";
 #define LOG_PREFIX cClassName + __func__ + "(" + std::to_string(__LINE__) + "):"
@@ -38,12 +37,11 @@ IasAvbVideoRingBufferFactory*  IasAvbVideoRingBufferFactory::getInstance()
 
 
 IasAvbVideoRingBufferFactory::IasAvbVideoRingBufferFactory()
-//  : mLog(&IasAvbStreamHandlerEnvironment::getDltContext("_RBF"))
   : mLog(nullptr)
   , mMemoryMap()
 {
-  mLog = new DltContext();
-  dlt_register_context(mLog, "_RBF", "Context for Ringbuffer");
+  mLog = &IasAvbVideoLog::getDltContext("_RBF");
+
   DLT_LOG_CXX(*mLog, DLT_LOG_VERBOSE, LOG_PREFIX);
 }
 
@@ -51,10 +49,6 @@ IasAvbVideoRingBufferFactory::IasAvbVideoRingBufferFactory()
 IasAvbVideoRingBufferFactory::~IasAvbVideoRingBufferFactory()
 {
   DLT_LOG_CXX(*mLog, DLT_LOG_VERBOSE, LOG_PREFIX);
-
-  dlt_unregister_context(mLog);
-  delete(mLog);
-  mLog = nullptr;
 }
 
 

--- a/private/src/avb_video_common/IasAvbVideoRingBufferShm.cpp
+++ b/private/src/avb_video_common/IasAvbVideoRingBufferShm.cpp
@@ -356,41 +356,6 @@ IasVideoRingBufferResult IasAvbVideoRingBufferShm::waitRead(pid_t pid, uint32_t 
   return result;
 }
 
-
-void IasAvbVideoRingBufferShm::resetFromWriter()
-{
-/* XXX another mutex should be taken for this, as currently readers are mostly lock-free - or send all readers to wait */
-  mMutexReadInProgress.lock();
-  mReadOffset  = 0;
-  mWriteOffset = 0;
-  mBufferLevel = 0;
-  mMutexReadInProgress.unlock();
-}
-
-/* XXX this doesn't make much sense when having multiple readers */
-void IasAvbVideoRingBufferShm::resetFromReader()
-{
-  mMutexWriteInProgress.lock();
-  mReadOffset  = 0;
-  mWriteOffset = 0;
-  mBufferLevel = 0;
-  mMutexWriteInProgress.unlock();
-}
-
-
-void IasAvbVideoRingBufferShm::zeroOut()
-{
-  // Lock both mutexes, to ensure nobody is accessing the buffer right now
-  /* XXX as reading is lock free, this needs a new approach, like sending all readers to wait */
-  mMutexReadInProgress.lock();
-  mMutexWriteInProgress.lock();
-  uint32_t sizeOfBufferInBytes = mNumBuffers * mBufferSize;
-  AVB_ASSERT(nullptr != getDataBuffer());
-  memset(getDataBuffer(), 0, sizeOfBufferInBytes);
-  mMutexWriteInProgress.unlock();
-  mMutexReadInProgress.unlock();
-}
-
 IasVideoRingBufferResult IasAvbVideoRingBufferShm::addReader(pid_t pid)
 {
   IasVideoRingBufferResult result = eIasRingBuffTooManyReaders;

--- a/private/src/avb_video_common/IasAvbVideoShmConnection.cpp
+++ b/private/src/avb_video_common/IasAvbVideoShmConnection.cpp
@@ -13,7 +13,7 @@
 
 #include "avb_video_common/IasAvbVideoShmConnection.hpp"
 #include "avb_video_common/IasAvbVideoRingBufferFactory.hpp"
-#include "avb_streamhandler/IasAvbStreamHandlerEnvironment.hpp"
+#include "avb_video_common/IasAvbVideoLog.hpp"
 
 #include <dlt/dlt_cpp_extension.hpp>
 
@@ -29,16 +29,13 @@ static const std::string cClassName = "IasAvbVideoShmConnection::";
  *  Constructor.
  */
 IasAvbVideoShmConnection::IasAvbVideoShmConnection(bool isCreator)
-//  : mLog(&IasAvbStreamHandlerEnvironment::getDltContext("_AVC"))
   : mLog(nullptr)
   , mRingBuffer(nullptr)
   , mIsCreator(isCreator)
   , mConnectionName()
   , mGroupName()
 {
-  // Need to do it here since this class is also used on client side where IasAvbStreamHandlerEnvironment isn't available
-  mLog = new DltContext();
-  dlt_register_context(mLog, "_AVC", "Context for video SHM connection");
+  mLog = &IasAvbVideoLog::getDltContext("_AVC");
 
   DLT_LOG_CXX(*mLog, DLT_LOG_VERBOSE, LOG_PREFIX);
 }
@@ -83,10 +80,6 @@ void IasAvbVideoShmConnection::cleanup()
   }
   mConnectionName.clear();
   mGroupName.clear();
-
-  dlt_unregister_context(mLog);
-  delete(mLog);
-  mLog = nullptr;
 }
 
 

--- a/private/src/gst/gstavbplugin.cpp
+++ b/private/src/gst/gstavbplugin.cpp
@@ -7,9 +7,19 @@
 #include "gst/gstavbvideosink.h"
 #include "gst/gstavbvideosrc.h"
 
+#include <dlt/dlt.h>
+
+DLT_DECLARE_CONTEXT(log_ctx);
+
 static gboolean
 plugin_init(GstPlugin * plugin)
 {
+    /* Log parameters to debug avb_video_bridge. Can be changed to help debug */
+    dlt_register_context_ll_ts(&log_ctx, "_VBDG", "Context for AVB Video Bridge",
+            DLT_LOG_INFO, DLT_TRACE_STATUS_OFF);
+    ias_avbvideobridge_register_log_context(&log_ctx);
+    dlt_enable_local_print();
+
     gst_element_register(plugin, "avbvideosink", GST_RANK_NONE,
             GST_TYPE_AVBVIDEOSINK);
     gst_element_register(plugin, "avbvideosrc", GST_RANK_NONE,

--- a/private/tst/avb_streamhandler/CMakeLists.txt
+++ b/private/tst/avb_streamhandler/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable( test_IasTestAvbStreamhandler
                 private/tst/avb_streamhandler/src/IasTestAvbConfigurationBase.cpp
                 private/tst/avb_streamhandler/src/IasTestAvbMain.cpp
                 private/tst/avb_streamhandler/src/IasTestAvbClockDriver.cpp
+                private/tst/avb_streamhandler/src/IasTestVideoRingBufferShm.cpp
                 )
 
 target_compile_options( test_IasTestAvbStreamhandler PRIVATE -Wno-error )

--- a/private/tst/avb_streamhandler/src/IasTestVideoRingBufferShm.cpp
+++ b/private/tst/avb_streamhandler/src/IasTestVideoRingBufferShm.cpp
@@ -1,0 +1,818 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file    IasTestVideoRingBufferShm.cpp
+ * @brief   The implementation of the IasTestVideoRingBufferShm test class.
+ * @date    2018
+ */
+
+#include "gtest/gtest.h"
+#define private public
+#define protected public
+#include "avb_video_common/IasAvbVideoRingBufferShm.hpp"
+#define protected protected
+#define private private
+
+namespace IasMediaTransportAvb
+{
+
+#define NSEC_PER_SEC 1000000000UL
+#define NOW_THRESHOLD 1000
+
+class IasTestVideoRingBufferShm : public ::testing::Test
+{
+protected:
+  IasTestVideoRingBufferShm()
+    : mRingBuffer()
+  {
+    DLT_REGISTER_APP("IAAS", "AVB Streamhandler");
+  }
+
+  ~IasTestVideoRingBufferShm()
+  {
+    DLT_UNREGISTER_APP();
+  }
+
+  void SetUp() override
+  {
+    mRingBuffer.init(cPacketSize, cNumPackets, (void *)&mBuffer, true);
+  }
+
+  static const uint32_t cNumPackets = 800u;
+  static const uint32_t cPacketSize = 1460u;
+  uint8_t mBuffer[cNumPackets * cPacketSize];
+  IasAvbVideoRingBufferShm mRingBuffer;
+};
+
+TEST_F(IasTestVideoRingBufferShm, addReader)
+{
+  // Invalid params
+  IasVideoRingBufferResult result = mRingBuffer.addReader(-1);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.addReader(0);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  for (int i = 0; i < cIasVideoRingBufferShmMaxReaders; i++)
+  {
+    result = mRingBuffer.addReader(i + 1); // Smallest accepted pid is 1
+    EXPECT_EQ(result, eIasRingBuffOk);
+  }
+
+  // To many readers
+  result = mRingBuffer.addReader(1);
+  EXPECT_EQ(result, eIasRingBuffTooManyReaders);
+}
+
+TEST_F(IasTestVideoRingBufferShm, removeReader)
+{
+  // Invalid params
+  IasVideoRingBufferResult result = mRingBuffer.removeReader(-1);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.removeReader(0);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Remove one that wasn't added
+  result = mRingBuffer.removeReader(1);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Add as many readers as possible
+  for (int i = 0; i < cIasVideoRingBufferShmMaxReaders; i++)
+  {
+    result = mRingBuffer.addReader(i + 1); // Smallest accepted pid is 1
+    ASSERT_EQ(result, eIasRingBuffOk);
+  }
+
+  // Then remove some on an unspecified order
+  result = mRingBuffer.removeReader(1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.removeReader(7);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.removeReader(cIasVideoRingBufferShmMaxReaders);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.removeReader(cIasVideoRingBufferShmMaxReaders - 1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.removeReader(2);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Five were removed, so we should be able to add five more
+  for (int i = 0; i < 5; i++)
+  {
+    result = mRingBuffer.addReader(i + 100);
+    ASSERT_EQ(result, eIasRingBuffOk);
+  }
+
+  // But nothing more
+  result = mRingBuffer.addReader(200);
+  EXPECT_EQ(result, eIasRingBuffTooManyReaders);
+
+  // Remove something after adding
+  result = mRingBuffer.removeReader(5);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.removeReader(100);
+  EXPECT_EQ(result, eIasRingBuffOk);
+}
+
+TEST_F(IasTestVideoRingBufferShm, findReader)
+{
+  // Add some readers
+  IasVideoRingBufferResult result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(2);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(3);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(4);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(5);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  // Find them
+  EXPECT_NE(mRingBuffer.findReader(1), nullptr);
+  EXPECT_NE(mRingBuffer.findReader(3), nullptr);
+  EXPECT_NE(mRingBuffer.findReader(2), nullptr);
+  EXPECT_NE(mRingBuffer.findReader(4), nullptr);
+  EXPECT_NE(mRingBuffer.findReader(5), nullptr);
+
+  // Do not find what wasn't there
+  EXPECT_EQ(mRingBuffer.findReader(-1), nullptr);
+  EXPECT_EQ(mRingBuffer.findReader(0), nullptr);
+  EXPECT_EQ(mRingBuffer.findReader(6), nullptr);
+
+  // Remove some
+  result = mRingBuffer.removeReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.removeReader(3);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  // Do not find those
+  EXPECT_EQ(mRingBuffer.findReader(1), nullptr);
+  EXPECT_EQ(mRingBuffer.findReader(3), nullptr);
+
+  // But still find what wasn't removed
+  EXPECT_NE(mRingBuffer.findReader(2), nullptr);
+  EXPECT_NE(mRingBuffer.findReader(4), nullptr);
+  EXPECT_NE(mRingBuffer.findReader(5), nullptr);
+}
+
+TEST_F(IasTestVideoRingBufferShm, calculateReaderBufferLevel)
+{
+  // Add a reader
+  IasVideoRingBufferResult result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  // "reader buffer level" is the amount of packets non read by
+  // some reader. It's usually the difference between was written
+  // by the writer, and what was read by the reader
+  // Each reader knows how much it read so far, so the only thing
+  // to test it check expectations regarding writer position (what it
+  // has written)
+
+  IasAvbVideoRingBufferShm::RingBufferReader *reader = mRingBuffer.findReader(1);
+  ASSERT_NE(reader, nullptr);
+
+  // In the beginning, reader read nothing, and writer wrote
+  // nothing
+  mRingBuffer.mWriteOffset = 0;
+  reader->offset = 0;
+  // So buffer level should be 0
+  EXPECT_EQ(mRingBuffer.calculateReaderBufferLevel(reader), 0);
+
+  // After some writing it should be all that was written
+  mRingBuffer.mWriteOffset = 400;
+  EXPECT_EQ(mRingBuffer.calculateReaderBufferLevel(reader), 400);
+
+  // Some reading, and level should decrease by what was read
+  reader->offset = 300;
+  EXPECT_EQ(mRingBuffer.calculateReaderBufferLevel(reader), 100);
+
+  // Writer goes to the end and so wraps to 0.
+  mRingBuffer.mWriteOffset = 0;
+  EXPECT_EQ(mRingBuffer.calculateReaderBufferLevel(reader), 500);
+
+  // Writer advances a bit
+  mRingBuffer.mWriteOffset = 100;
+  EXPECT_EQ(mRingBuffer.calculateReaderBufferLevel(reader), 600);
+}
+
+TEST_F(IasTestVideoRingBufferShm, aggregateReaderOffset)
+{
+  // Add some readers
+  IasVideoRingBufferResult result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(2);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(3);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  IasAvbVideoRingBufferShm::RingBufferReader *reader1 = mRingBuffer.findReader(1);
+  ASSERT_NE(reader1, nullptr);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader2 = mRingBuffer.findReader(2);
+  ASSERT_NE(reader2, nullptr);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader3 = mRingBuffer.findReader(3);
+  ASSERT_NE(reader3, nullptr);
+
+  // No one read anything, so we're still on zero
+  mRingBuffer.aggregateReaderOffset();
+  EXPECT_EQ(mRingBuffer.mReadOffset, 0);
+
+  // Some advance, but not all, so we're still on zero
+  reader1->offset = 300;
+  reader2->offset = 200;
+  mRingBuffer.aggregateReaderOffset();
+  EXPECT_EQ(mRingBuffer.mReadOffset, 0);
+
+  // Now reader2 lags behind
+  reader3->offset = 300;
+  mRingBuffer.aggregateReaderOffset();
+  EXPECT_EQ(mRingBuffer.mReadOffset, 200);
+
+  // One more round of advancements
+  reader1->offset = 600;
+  reader2->offset = 500;
+  reader3->offset = 700;
+  mRingBuffer.aggregateReaderOffset();
+  EXPECT_EQ(mRingBuffer.mReadOffset, 500);
+
+  // Some reach the end, but not all
+  reader1->offset = cNumPackets;
+  reader2->offset = cNumPackets;
+  mRingBuffer.aggregateReaderOffset();
+  EXPECT_EQ(mRingBuffer.mReadOffset, 700);
+
+  // When all reach the end, mReadOffset wraps to zero
+  reader3->offset = cNumPackets;
+  mRingBuffer.aggregateReaderOffset();
+  EXPECT_EQ(mRingBuffer.mReadOffset, 0);
+}
+
+TEST_F(IasTestVideoRingBufferShm, updateSmallerReaderOffset)
+{
+  // This method is called by aggregateReaderOffset, so most of what
+  // it does should be already tested. Here, we are interested in
+  // a) Does it resets all readers offset when they reach the end,
+  // b) Does it not reset anything before that
+
+  // XXX: some C++ trickery prevents gtest functions (such as EXPECT_EQ)
+  // from seeing this static member of IasAvbVideoRingBufferShm. Find
+  // out a beautiful solution. For now, we use a local variable
+  uint32_t numPackets = cNumPackets;
+
+  // Before adding any reader, it should return UINT32_MAX
+  EXPECT_EQ(mRingBuffer.updateSmallerReaderOffset(), UINT32_MAX);
+
+  // Add some readers
+  IasVideoRingBufferResult result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(2);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(3);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  IasAvbVideoRingBufferShm::RingBufferReader *reader1 = mRingBuffer.findReader(1);
+  ASSERT_NE(reader1, nullptr);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader2 = mRingBuffer.findReader(2);
+  ASSERT_NE(reader2, nullptr);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader3 = mRingBuffer.findReader(3);
+  ASSERT_NE(reader3, nullptr);
+
+  // In the beginning, everything is at zero
+  EXPECT_EQ(mRingBuffer.updateSmallerReaderOffset(), 0);
+  EXPECT_EQ(reader1->offset, 0);
+  EXPECT_EQ(reader1->offset, 0);
+  EXPECT_EQ(reader1->offset, 0);
+
+  // Advance them in assorted ways
+  reader1->offset = 0;
+  reader2->offset = 500;
+  reader3->offset = 700;
+  EXPECT_EQ(mRingBuffer.updateSmallerReaderOffset(), 0);
+  EXPECT_EQ(reader1->offset, 0);
+  EXPECT_EQ(reader2->offset, 500);
+  EXPECT_EQ(reader3->offset, 700);
+
+  // One more time
+  reader1->offset = 600;
+  reader2->offset = 700;
+  reader3->offset = 750;
+  EXPECT_EQ(mRingBuffer.updateSmallerReaderOffset(), 600);
+  EXPECT_EQ(reader1->offset, 600);
+  EXPECT_EQ(reader2->offset, 700);
+  EXPECT_EQ(reader3->offset, 750);
+
+  // One reaches the end
+  reader1->offset = numPackets;
+  reader2->offset = 750;
+  reader3->offset = 770;
+  EXPECT_EQ(mRingBuffer.updateSmallerReaderOffset(), 750);
+  EXPECT_EQ(reader1->offset, numPackets);
+  EXPECT_EQ(reader2->offset, 750);
+  EXPECT_EQ(reader3->offset, 770);
+
+  // When all reach, their offset goes to zero
+  reader1->offset = numPackets;
+  reader2->offset = numPackets;
+  reader3->offset = numPackets;
+  EXPECT_EQ(mRingBuffer.updateSmallerReaderOffset(), 800);
+  EXPECT_EQ(reader1->offset, 0);
+  EXPECT_EQ(reader2->offset, 0);
+  EXPECT_EQ(reader3->offset, 0);
+}
+
+TEST_F(IasTestVideoRingBufferShm, updateAvailable)
+{
+  uint32_t numBuffers;
+  uint32_t numPackets = cNumPackets;
+
+  // Test some invalid params
+  IasVideoRingBufferResult result = mRingBuffer.updateAvailable(eIasRingBufferAccessRead, 0, nullptr);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessRead, 0, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessUndef, 0, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessWrite, 0, nullptr);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Add a reader
+  result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  // In the beginning, it should have everything available to writing,
+  // and nothing to read
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessWrite, 0, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(numBuffers, numPackets);
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessRead, 1, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(numBuffers, 0);
+
+  // Adjust variables to simulate some writing
+  mRingBuffer.mBufferLevel = 400;
+  mRingBuffer.mWriteOffset = 400;
+
+  // Now, there should be 400 for read, and numPackets - 400 for writing
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessWrite, 0, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(numBuffers, numPackets - 400);
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessRead, 1, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(numBuffers, 400);
+
+  // After some reading, there should be less to read
+  // Note that we don't update global variables that control what was
+  // read - so we simulate a case in which there's another reader,
+  // that reads nothing
+  IasAvbVideoRingBufferShm::RingBufferReader *reader = mRingBuffer.findReader(1);
+  ASSERT_NE(reader, nullptr);
+  reader->offset = 300;
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessRead, 1, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(numBuffers, 100);
+
+  // If more is writen and writer wraps, there should be a lot to read
+  // (that doesn't include what was read)
+  mRingBuffer.mBufferLevel = numPackets - 50;
+  mRingBuffer.mWriteOffset = 100;
+  mRingBuffer.mReadOffset = 150; // Simulate another reader, slower, that hedges
+                                 // global read offset
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessRead, 1, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  // all that's available till the end of the buffer, less what was read, plus
+  // what wrapped by writer
+  EXPECT_EQ(numBuffers, numPackets - 300 + mRingBuffer.mWriteOffset);
+
+  // And just some to write
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessWrite, 0, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(numBuffers, 50); // Writer may never go beyond what wasn't read yet
+                             // If this rule changes, this test changes
+
+  // And nothing more to write after write to the end
+  mRingBuffer.mBufferLevel = numPackets;
+
+  result = mRingBuffer.updateAvailable(eIasRingBufferAccessWrite, 0, &numBuffers);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(numBuffers, 0);
+}
+
+TEST_F(IasTestVideoRingBufferShm, access)
+{
+  // Tests several readers and one writer access to a buffer
+  // Note that things run linearly, concurrency scenarios are
+  // not explored here
+
+  uint32_t numBuffersWriter, numBuffersReader1, numBuffersReader2, numBuffersReader3;
+  uint32_t offsetWriter, offsetReader1, offsetReader2, offsetReader3;
+  uint32_t numPackets = cNumPackets;
+
+  // Add some readers
+  IasVideoRingBufferResult result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(2);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(3);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  // Some invalid params
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessUndef, 0, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 0, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, nullptr, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader1, nullptr);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 0, nullptr, nullptr);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 1, nullptr, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 1, &offsetWriter, nullptr);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, nullptr, nullptr);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // In the beginning, all access should be ok, readers with nothing to read,
+  // writer with all it wants to write
+  numBuffersReader1 = 100; // How many packets we want to read?
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader1, 0);
+  EXPECT_EQ(numBuffersReader1, 0);
+
+  numBuffersReader2 = 0; // Not common, but a reader that just wants to be kept 'alive' would do this
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 2, &offsetReader2, &numBuffersReader2);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader2, 0);
+  EXPECT_EQ(numBuffersReader2, 0);
+
+  numBuffersWriter = 400;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetWriter, 0);
+  EXPECT_EQ(numBuffersWriter, 400);
+
+  // A writer may not call beginAccess again before calling endAccess
+  numBuffersWriter = 400;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffNotAllowed);
+
+  // But there's no restrictions for readers
+  // TODO should we add restrictions?
+  numBuffersReader1 = 100; // How many packets we want to read?
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader1, 0);
+  EXPECT_EQ(numBuffersReader1, 0);
+
+  // Good practice though tell us to end all read access, had we read anything or not
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 1, 0, 0);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 2, 0, 0);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Finish writer access, writing half of what was available
+  // Note that offset field on endAccess is unused (maybe remove it?)
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, 200);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 0); // No reads so far
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 200);
+  EXPECT_EQ(mRingBuffer.mBufferLevel, 200);
+
+  // Write a bit more
+  numBuffersWriter = 2 * numPackets; //asks for a really big number
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetWriter, 200);
+  EXPECT_EQ(numBuffersWriter, numPackets - 200); // But should only get buffer size less what is already there
+
+  // Finish writing. First try to say the it wrote more than possible
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, numPackets);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Then do the right thing (just add 100)
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, 100);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 0); // No reads so far
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 300);
+  EXPECT_EQ(mRingBuffer.mBufferLevel, 300);
+
+  // Each reader reads some
+  numBuffersReader1 = 200;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader1, 0);
+  EXPECT_EQ(numBuffersReader1, 200);
+
+  numBuffersReader2 = 400; // Tries to read more than available
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 2, &offsetReader2, &numBuffersReader2);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader2, 0);
+  EXPECT_EQ(numBuffersReader2, 300); // But only gets what is available
+
+  numBuffersReader3 = 300;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 3, &offsetReader3, &numBuffersReader3);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader3, 0);
+  EXPECT_EQ(numBuffersReader3, 300);
+
+  // First reader ends its access, stating that it read less than available
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 1, 0, 100);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Second reads everything
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 2, 0, 300);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Third lies and tries to write more than possible
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 3, 0, 400);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Writer starts access again
+  numBuffersWriter = 400;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetWriter, 300);
+  EXPECT_EQ(numBuffersWriter, 400);
+
+  // Third reader properly finishes access
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 3, 0, 300);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Second reader starts access again
+  numBuffersReader2 = 400; // Tries to read more than available
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 2, &offsetReader2, &numBuffersReader2);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader2, 300);
+  EXPECT_EQ(numBuffersReader2, 0); // But only gets what is available. Nothing, as writer didn't finish yet
+
+  // Writer finishes
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, 300);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 100); // Slowest reader, the first, only read 100
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 600);
+  EXPECT_EQ(mRingBuffer.mBufferLevel, 500);
+
+  // Second reader finishes. But it lies: it tells that it read more
+  // than was available when it begun. Despite writer having written something,
+  // this test should fail as it may not read more than was "granted" on beginAccess
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 2, 0, 300);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Writer goes to the end. It should only wrap on next access
+  numBuffersWriter = 400;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetWriter, 600);
+  EXPECT_EQ(numBuffersWriter, numPackets - 600);
+
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, numPackets - 600);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 100); // Slowest reader, the first, only read 100
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 0); // Wraps over
+  EXPECT_EQ(mRingBuffer.mBufferLevel, 700);
+
+  // Some more reading
+  numBuffersReader1 = 500;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader1, 100);
+  EXPECT_EQ(numBuffersReader1, 500);
+
+  numBuffersReader2 = numPackets; // Tries to read more than available
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 2, &offsetReader2, &numBuffersReader2);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader2, 300);
+  EXPECT_EQ(numBuffersReader2, 500); // But only gets what is available
+
+  numBuffersReader3 = 500;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 3, &offsetReader3, &numBuffersReader3);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader3, 300);
+  EXPECT_EQ(numBuffersReader3, 500);
+
+  // First reader ends its access, stating that it read less than available
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 1, 0, 400);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Second reads everything and reaches the end
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 2, 0, 500);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Third also finishes
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 3, 0, 500);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 500); // Slowest reader, the first, still on 500
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 0);
+  EXPECT_EQ(mRingBuffer.mBufferLevel, 300);
+
+  // Writer starts from beginning 
+  numBuffersWriter = numPackets;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetWriter, 0);
+  EXPECT_EQ(numBuffersWriter, 499); // Stops short from having everything available, as one reader is slow
+
+  // But it lies stating that wrote all
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, numPackets);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Tries again with correct value
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, 499);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 500); // Slowest reader, the first, still on 500
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 499);
+  EXPECT_EQ(mRingBuffer.mBufferLevel, 799);
+
+  // Writer goes again
+  numBuffersWriter = numPackets;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetWriter, 499);
+  EXPECT_EQ(numBuffersWriter, 0); // Nothing available, first reader still on 500
+
+  // First reader finally reads everything and all readers wraps
+  numBuffersReader1 = numPackets;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader1, 500);
+  EXPECT_EQ(numBuffersReader1, numPackets - 500);
+
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 1, 0, numPackets - 500);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Writer finishes, stating that it wrote something. Even though slowed reader
+  // read something (so there's space on buffer), writer should not write more than
+  // was "granted" on beginAccess
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, 300);
+  EXPECT_EQ(result, eIasRingBuffInvalidParam);
+
+  // Writer retries with correct value
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, 0);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 0); // All readers wrap together
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 499);
+  EXPECT_EQ(mRingBuffer.mBufferLevel, 499);
+
+  // One more round of reading, after the wrapping
+  numBuffersReader1 = 200;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader1, &numBuffersReader1);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader1, 0);
+  EXPECT_EQ(numBuffersReader1, 200);
+
+  numBuffersReader2 = 500; // Tries to read more than available
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 2, &offsetReader2, &numBuffersReader2);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader2, 0);
+  EXPECT_EQ(numBuffersReader2, 499); // But only gets what is available
+
+  numBuffersReader3 = 300;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 3, &offsetReader3, &numBuffersReader3);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetReader3, 0);
+  EXPECT_EQ(numBuffersReader3, 300);
+
+  // First reader ends its acces, stating that it read less than available
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 1, 0, 100);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Second reads everything
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 2, 0, 499);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Third reads what it asked for
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 3, 0, 300);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Writer advances till the end
+  numBuffersWriter = numPackets;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_EQ(offsetWriter, 499);
+  EXPECT_EQ(numBuffersWriter, 301);
+
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, 0, 301);
+  EXPECT_EQ(result, eIasRingBuffOk);
+
+  // Sanity check of global variables
+  EXPECT_EQ(mRingBuffer.mReadOffset, 100); // Slowest reader
+  EXPECT_EQ(mRingBuffer.mWriteOffset, 0);
+  EXPECT_EQ(mRingBuffer.mBufferLevel, numPackets - 100);
+}
+
+TEST_F(IasTestVideoRingBufferShm, updateReaderAccess)
+{
+  // updateReaderAccess is an internal method, so it never expects its
+  // parameter to be NULL
+
+  // Add the reader and get it
+  IasVideoRingBufferResult result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader = mRingBuffer.findReader(1);
+  ASSERT_NE(reader, nullptr);
+
+  reader->lastAccess = 0;
+
+  mRingBuffer.updateReaderAccess(reader);
+  EXPECT_NE(reader->lastAccess, 0);
+}
+
+TEST_F(IasTestVideoRingBufferShm, updateReaderAccessUse)
+{
+  // This test checks if methods that should update reader->lastAccess
+  // do that
+
+  uint32_t offsetReader, numBuffersReader, offsetWriter, numBuffersWriter = 300;
+
+  // Let's "write" something so mRingBuffer current state allows some reading
+  IasVideoRingBufferResult result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, offsetWriter, numBuffersWriter);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  // First one is the one that adds a reader
+  result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader = mRingBuffer.findReader(1);
+  ASSERT_NE(reader, nullptr);
+  EXPECT_NE(reader->lastAccess, 0);
+
+  // Now let's check begin access
+  reader->lastAccess = 0;
+  numBuffersReader = 100;
+  result = mRingBuffer.beginAccess(eIasRingBufferAccessRead, 1, &offsetReader, &numBuffersReader);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_NE(reader->lastAccess, 0);
+
+  // End access
+  reader->lastAccess = 0;
+  numBuffersReader = 100;
+  result = mRingBuffer.endAccess(eIasRingBufferAccessRead, 1, offsetReader, numBuffersReader);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_NE(reader->lastAccess, 0);
+
+  // Finally, on wait read - note that this method should return immediately,
+  // as there should be things to read
+  mRingBuffer.mWriteOffset = 200;
+  mRingBuffer.mBufferLevel = 200;
+  reader->lastAccess = 0;
+  result = mRingBuffer.waitRead(1, 100, 100);
+  EXPECT_EQ(result, eIasRingBuffOk);
+  EXPECT_NE(reader->lastAccess, 0);
+}
+
+TEST_F(IasTestVideoRingBufferShm, purgeUnresponsiveReaders)
+{
+  // Add some readers
+  IasVideoRingBufferResult result = mRingBuffer.addReader(1);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(2);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  result = mRingBuffer.addReader(3);
+  ASSERT_EQ(result, eIasRingBuffOk);
+
+  IasAvbVideoRingBufferShm::RingBufferReader *reader1 = mRingBuffer.findReader(1);
+  ASSERT_NE(reader1, nullptr);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader2 = mRingBuffer.findReader(2);
+  ASSERT_NE(reader2, nullptr);
+  IasAvbVideoRingBufferShm::RingBufferReader *reader3 = mRingBuffer.findReader(3);
+  ASSERT_NE(reader3, nullptr);
+
+  // Now we pretend that readers 2 and 3 have an old lastAccess time
+  reader1->lastAccess -= 3 * NSEC_PER_SEC;
+  reader3->lastAccess -= 3 * NSEC_PER_SEC;
+
+  mRingBuffer.purgeUnresponsiveReaders();
+
+  EXPECT_EQ(reader1->pid, 0);
+  EXPECT_EQ(reader3->pid, 0);
+
+  // Reader 2 should be untouched
+  EXPECT_EQ(reader2->pid, 2);
+}
+
+}

--- a/public/inc/media_transport/avb_video_bridge/IasAvbVideoBridge.h
+++ b/public/inc/media_transport/avb_video_bridge/IasAvbVideoBridge.h
@@ -17,6 +17,7 @@
 
 #include <stddef.h>
 
+#include <dlt/dlt.h>
 
 #if defined( __cplusplus )
 extern "C"
@@ -78,6 +79,18 @@ struct ias_avbvideobridge_sender;
  */
 struct ias_avbvideobridge_receiver;
 
+/**
+ * @brief Register a DLT log context for avbvideobridge.
+ *
+ * For applications not linked to AVB-SH (the non AVB-SH side of the bridge),
+ * this function allows a default DLT context to be defined for log generated
+ * by avbvideobridge code. If no DLT context is registered, avbvideobridge
+ * code will use a dummy DLT context.
+ *
+ * @param[in] dlt_context DLT context to be used, or NULL to unregister
+ * previously registered context.
+ */
+void ias_avbvideobridge_register_log_context(DltContext *dlt_context);
 
 /**
  * @brief Create a sender instance of the avbvideobridge.


### PR DESCRIPTION
This series adds the multi-client feature for video. Here, client is the external application (like the gstreamer plugin) that connects to AVB Video Bridge to show video on the listener side of the TSN connection.

A simple way to test this feature is to run several gstreamer instances on the listener side, connecting to the same stream: all of them should show the same video.

Some unit tests are also available. Note that they are focused on the shared memory video ringbuffer - the core of multi-client. Higher levels APIs are not tested, nor any concurrency aspect of this code (that has several).

Note 1: This PR is against branch `next` of AVBStreamHandler, it is not meant for master yet, but this is the PR for it. Once approved, it will land on branch `next`, and no more reviews will happen when `next` itself is merged on `master`.

Note 2: Patches `environment: Make...` to `gstreamer plugin: Use DLT...` deal with logging on the AVB Video Bridge. As this code is also supposed to link against external applications (and not only AVB-SH), it can't log like the rest of AVB-SH. Those patches propose a naive solution to that: provide the external application APIs so that it can set up a DLT context for the bridge. The obvious downside is that DLT is mandatory on the bridge. We can revisit this later - or even drop all of this now and go with `fprintf`. Please, share any thoughts on this.