### PR TITLE
Handling AVB Video Bridge server crash

### DIFF
--- a/private/inc/avb_streamhandler/IasLocalVideoOutStream.hpp
+++ b/private/inc/avb_streamhandler/IasLocalVideoOutStream.hpp
@@ -89,6 +89,17 @@ class IasLocalVideoOutStream : public IasLocalVideoStream
     IasAvbProcessingResult pushPayload(PacketMpegTS const & packet);
 
     /*!
+     * @brief Sends null packet to local ring buffer
+     *
+     * This will allow client to track liveliness of the server, as
+     * local ring buffer keeps the last time of access made by the
+     * server
+     *
+     * @returns    eIasAvbProcOK on success, otherwise an error code.
+     */
+    IasAvbProcessingResult pushNull();
+
+    /*!
      * @brief Reset video buffer to initial state
      */
     IasAvbProcessingResult resetBuffers();

--- a/private/inc/avb_video_bridge/IasAvbVideoReceiver.hpp
+++ b/private/inc/avb_video_bridge/IasAvbVideoReceiver.hpp
@@ -75,6 +75,16 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoReceiver
      */
     ias_avbvideobridge_result setCallback(ias_avbvideobridge_receive_MpegTS_cb cb, void* userPtr);
 
+    /*!
+     * @brief Time of writer last access time to stream.
+     *
+     * Readers can check the liveliness of writer by ensuring this time doesn't
+     * get too distant from now.
+     *
+     * @returns Last access time in nanoseconds.
+     */
+    uint64_t getLastStreamWriteAccess();
+
     // currently not used
     uint32_t getInstCounter() { return uint32_t(mNumberInstances); }
 

--- a/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBuffer.hpp
@@ -226,6 +226,16 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBuffer
      */
     IasVideoRingBufferResult removeReader(pid_t pid);
 
+    /*!
+     * @brief Time of writer last access to the ring buffer.
+     *
+     * Readers can check the liveliness of writer by ensuring this time doesn't
+     * get too distant from now.
+     *
+     * @returns Last access time in nanoseconds.
+     */
+    uint64_t getWriterLastAccess();
+
   private:
     /*!
      *  @brief Copy constructor, private unimplemented to prevent misuse.

--- a/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
+++ b/private/inc/avb_video_common/IasAvbVideoRingBufferShm.hpp
@@ -201,6 +201,18 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
      */
     IasVideoRingBufferResult removeReader(pid_t pid);
 
+    /*!
+     * @brief Time of writer last access to the ring buffer.
+     *
+     * Readers can check the liveliness of writer by ensuring this time doesn't
+     * get too distant from now.
+     *
+     * @returns Last access time in nanoseconds.
+     */
+    uint64_t getWriterLastAccess() {
+        return mWriterLastAccess;
+    }
+
   private:
 
     /* Struct to keep track of reader register to read on this RingBuffer */
@@ -280,6 +292,11 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
       return nullptr;
     };
 
+    /*!
+     * @brief updates lastAccess for writer, so it's possible to track writer death by timeout
+     */
+    void updateWriterAccess();
+
     /* As this class lives on shared memory, it can *not* save anything that
      * is related to any process, like the log context. It needs to get it every
      * time, so to get the right log context for the calling process */
@@ -309,6 +326,7 @@ class __attribute__ ((visibility ("default"))) IasAvbVideoRingBufferShm
     uint32_t                              mReadWaitLevel;        //!< buffer level that must be reached before a signal is sent
     uint32_t                              mWriteWaitLevel;       //!< buffer level that must be reached before a signal is sent
     uint32_t                              mAllowedToWrite;       //!< how many buffers (packets) were allowed to writer on last beginAccess
+    uint64_t                              mWriterLastAccess;     //!< writer last access time
 
     IasIntProcMutex                       mMutexReaders;                              //!< Protects access to mReaders array
     RingBufferReader                      mReaders[cIasVideoRingBufferShmMaxReaders]; //!< List of active readers

--- a/private/src/avb_streamhandler/IasAvbVideoStream.cpp
+++ b/private/src/avb_streamhandler/IasAvbVideoStream.cpp
@@ -1047,6 +1047,12 @@ void IasAvbVideoStream::readFromAvbPacket(const void* const packet, const size_t
         }
       }
     }
+
+    if (IasAvbStreamState::eIasAvbStreamNoData == newState)
+    {
+      // Nothing to send, but writting null to localstram notes that we're still alive
+      mLocalStream->writeLocalVideoBuffer(NULL, NULL);
+    }
   }
 
   mLock.unlock();

--- a/private/src/avb_video_bridge/IasAvbVideoBridge.cpp
+++ b/private/src/avb_video_bridge/IasAvbVideoBridge.cpp
@@ -138,6 +138,15 @@ IAS_DSO_PUBLIC ias_avbvideobridge_result ias_avbvideobridge_register_MpegTS_cb(i
   return res;
 }
 
+IAS_DSO_PUBLIC uint64_t ias_avbvideobridge_last_receiver_access(ias_avbvideobridge_receiver* inst)
+{
+  if (NULL != inst)
+  {
+    return reinterpret_cast<IasAvbVideoReceiver*>(inst)->getLastStreamWriteAccess();
+  }
+
+  return 0;
+}
 
 #if defined( __cplusplus )
 }

--- a/private/src/avb_video_bridge/IasAvbVideoReceiver.cpp
+++ b/private/src/avb_video_bridge/IasAvbVideoReceiver.cpp
@@ -298,6 +298,13 @@ ias_avbvideobridge_result IasAvbVideoReceiver::setCallback(ias_avbvideobridge_re
   return res;
 }
 
+uint64_t IasAvbVideoReceiver::getLastStreamWriteAccess()
+{
+  AVB_ASSERT(nullptr != mRingBuffer); // Worker thread is started after successful connection to ring buffer
+
+  return mRingBuffer->getWriterLastAccess();
+}
+
 } // namespace IasMediaTransportAvb
 
 

--- a/private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
+++ b/private/src/avb_video_common/IasAvbVideoRingBuffer.cpp
@@ -309,6 +309,19 @@ IasVideoRingBufferResult IasAvbVideoRingBuffer::removeReader(pid_t pid)
   return eIasRingBuffNotAllowed;
 }
 
+uint64_t IasAvbVideoRingBuffer::getWriterLastAccess()
+{
+  if (nullptr == mRingBufShm)
+  {
+    AVB_ASSERT(false);
+  }
+  else if (mIsShm)
+  {
+    return mRingBufShm->getWriterLastAccess();
+  }
+
+  return 0;
+}
 } // namespace IasMediaTransportAvb
 
 

--- a/private/tst/avb_streamhandler/src/IasTestVideoRingBufferShm.cpp
+++ b/private/tst/avb_streamhandler/src/IasTestVideoRingBufferShm.cpp
@@ -815,4 +815,33 @@ TEST_F(IasTestVideoRingBufferShm, purgeUnresponsiveReaders)
   EXPECT_EQ(reader2->pid, 2);
 }
 
+TEST_F(IasTestVideoRingBufferShm, updateWriterAccess)
+{
+  mRingBuffer.mWriterLastAccess = 0;
+
+  mRingBuffer.updateWriterAccess();
+
+  EXPECT_NE(mRingBuffer.mWriterLastAccess, 0);
+}
+
+TEST_F(IasTestVideoRingBufferShm, updateWriterAccessUse)
+{
+  // This test checks if methods that should update mWriterLastAccess
+  // do that
+
+  uint32_t offsetReader, numBuffersReader, offsetWriter, numBuffersWriter = 300;
+
+  // begin access is one
+  mRingBuffer.mWriterLastAccess = 0;
+  IasVideoRingBufferResult result = mRingBuffer.beginAccess(eIasRingBufferAccessWrite, 0, &offsetWriter, &numBuffersWriter);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  EXPECT_NE(mRingBuffer.mWriterLastAccess, 0);
+
+  // end access the other
+  mRingBuffer.mWriterLastAccess = 0;
+  result = mRingBuffer.endAccess(eIasRingBufferAccessWrite, 0, offsetWriter, numBuffersWriter);
+  ASSERT_EQ(result, eIasRingBuffOk);
+  EXPECT_NE(mRingBuffer.mWriterLastAccess, 0);
+}
+
 }

--- a/public/inc/media_transport/avb_video_bridge/IasAvbVideoBridge.h
+++ b/public/inc/media_transport/avb_video_bridge/IasAvbVideoBridge.h
@@ -204,6 +204,15 @@ ias_avbvideobridge_result ias_avbvideobridge_register_H264_cb(ias_avbvideobridge
  */
 ias_avbvideobridge_result ias_avbvideobridge_register_MpegTS_cb(ias_avbvideobridge_receiver* inst, ias_avbvideobridge_receive_MpegTS_cb cb, void* user_ptr);
 
+/**
+ * @brief Last access time of writer end on the bridge.
+ *
+ * Readers can check the liveliness of writer by ensuring this time doesn't
+ * get too distant from now.
+ *
+ * @returns Last access time in nanoseconds.
+ */
+uint64_t ias_avbvideobridge_last_receiver_access(ias_avbvideobridge_receiver* inst);
 
 #if defined( __cplusplus )
 }


### PR DESCRIPTION
This PR exposes a new AVB Video Bridge API so that clients (non AVB-SH side) on listener can check that AVB-SH is still alive (or not). 

Note: This PR is still against `next` branch.