### PR TITLE
tests: Fix assert for create watchdog unit test

### DIFF
--- a/private/src/avb_streamhandler/IasAvbStreamHandler.cpp
+++ b/private/src/avb_streamhandler/IasAvbStreamHandler.cpp
@@ -435,7 +435,21 @@ IasAvbProcessingResult IasAvbStreamHandler::init( const std::string& configName,
         // TODO: Add a config option to receive user input to disable avb_watchdog at runtime.
         //       Otherwise, would not be able to start by executing the demo_app normally
         //       since WATCHDOG_USEC is set by systemctl.
-        if (mEnvironment->createWatchdog() != eIasAvbProcOK)
+        result = mEnvironment->createWatchdog();
+        if (result == eIasAvbProcInvalidParam)
+        {
+          uint64_t wd_en = 0;
+          DLT_LOG_CXX(*mLog, DLT_LOG_WARN, LOG_PREFIX,
+                      "WATCHDOG_USEC is not configured!");
+
+          mEnvironment->getConfigValue(IasRegKeys::cUseWatchdog, wd_en);
+          if (wd_en)
+              DLT_LOG_CXX(*mLog, DLT_LOG_WARN, LOG_PREFIX,
+                          "Watchdog won't work. Please configure WATCHDOG_USEC.");
+
+          result = eIasAvbProcOK;
+        }
+        else if (result != eIasAvbProcOK)
         {
           DLT_LOG_CXX(*mLog, DLT_LOG_ERROR, LOG_PREFIX, " Init of watchdog failed");
           result = eIasAvbProcInitializationFailed;

--- a/private/src/avb_streamhandler/IasAvbStreamHandlerEnvironment.cpp
+++ b/private/src/avb_streamhandler/IasAvbStreamHandlerEnvironment.cpp
@@ -1204,13 +1204,8 @@ IasAvbProcessingResult IasAvbStreamHandlerEnvironment::createWatchdog()
     }
     else
     {
-      /*
-       * no watchdog configuration found in env 'WATCHDOG_USEC'.
-       * Treat this as a normal use case since users might now want to use either systemd or
-       * systemd's watchdog feature.
-       */
       mUseWatchdog = false;
-      ret = eIasAvbProcOK; // success
+      ret = eIasAvbProcInvalidParam;
     }
 
     if (mUseWatchdog)
@@ -1261,7 +1256,7 @@ IasAvbProcessingResult IasAvbStreamHandlerEnvironment::createWatchdog()
     }
   }
 
-  if (eIasAvbProcOK != ret)
+  if (eIasAvbProcOK != ret && eIasAvbProcInvalidParam != ret)
   {
     destroyWatchdog();
   }

--- a/private/tst/avb_streamhandler/src/IasTestAvbStreamHandlerEnvironment.cpp
+++ b/private/tst/avb_streamhandler/src/IasTestAvbStreamHandlerEnvironment.cpp
@@ -439,7 +439,7 @@ TEST_F(IasTestAvbStreamHandlerEnvironment, create_destroyWatchdog)
 {
   ASSERT_TRUE(mIasAvbStreamHandlerEnvironment != NULL);
 
-  ASSERT_EQ(eIasAvbProcInitializationFailed, mIasAvbStreamHandlerEnvironment->createWatchdog());
+  ASSERT_EQ(eIasAvbProcInvalidParam, mIasAvbStreamHandlerEnvironment->createWatchdog());
 
   std::string wdEnvVar("WATCHDOG_USEC");
   std::string wdTimeoutUSec("100000");


### PR DESCRIPTION
Creating watchdog on a stream handler environment object
without first setting the Systemd WATCHDOG_USEC variable
should be treated normally (not a failure) as the user
might not want to use Systemd or its application watchdog.

Signed-off-by: Tarun Vyas <tarun.vyas@intel.com>