### PR TITLE
tests: Create watchdog before initializing transmit sequencer

### DIFF
--- a/private/tst/avb_streamhandler/src/IasTestAvbTransmitSequencer.cpp
+++ b/private/tst/avb_streamhandler/src/IasTestAvbTransmitSequencer.cpp
@@ -277,6 +277,10 @@ TEST_F(IasTestAvbTransmitSequencer, initBwRateNeg)
   std::string optName = std::string(IasRegKeys::cDebugXmitShaperBwRate) + IasAvbTSpec::getClassSuffix(srClass);
   mEnvironment->setConfigValue(optName, 101u);
   mEnvironment->setConfigValue(IasRegKeys::cUseWatchdog, 1u);
+  ASSERT_EQ(setenv("WATCHDOG_USEC", "30000000", 1), 0);
+  /* ASSERT is required here, otherwise init will fail */
+  ASSERT_EQ(eIasAvbProcOK, mEnvironment->createWatchdog());
+
   result = mSequencer->init(0u, srClass, false);
   ASSERT_EQ(eIasAvbProcOK, result);
 }


### PR DESCRIPTION
Watchdog manager needs to be created when cUseWatchdog flag
is set before initializing the transmit sequencer.

Signed-off-by: Tarun Vyas <tarun.vyas@intel.com>