### PR TITLE
RTP-H.264 support for avbvideosink and avbvideosrc elements.

### DIFF
--- a/private/inc/gst/gstavbvideosink.h
+++ b/private/inc/gst/gstavbvideosink.h
@@ -27,6 +27,7 @@ struct _GstAvbVideoSink
 
     struct ias_avbvideobridge_sender *sender;
     gchar *stream_name;
+    gboolean is_mpegts;
 };
 
 struct _GstAvbVideoSinkClass

--- a/private/inc/gst/gstavbvideosrc.h
+++ b/private/inc/gst/gstavbvideosrc.h
@@ -33,6 +33,7 @@ struct _GstAvbVideoSrc
     GAsyncQueue *queue;
     gchar *stream_name;
     gboolean done;
+    guint stream_type;
 };
 
 struct _GstAvbVideoSrcClass


### PR DESCRIPTION
This adds the RTP-H.264 capabilities to the avbvideosink and avbvideosrc gstreamer elements which enables visualizing RTP encapsulated H.264 packets for AVB StreamHandler.