### PR TITLE
README: Update instructions for igb_avb module

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ $ sudo chgrp ias_avb /dev/igb_avb
 $ sudo chmod 660 /dev/ptp*
 $ sudo chgrp ias_avb /dev/ptp*
 
+# If the module igb_avb is loaded by default on boot, reinsert the module: #
+$ rmmod igb_avb
+$ sudo insmod /lib/modules/<kernel-ver>/kernel/drivers/staging/igb_avb/igb_avb.ko tx_size=1024
+
 # Start the DLT daemon (for logging and tracing) #
+
 
 $ dlt-daemon -d (to daemonize)
 

--- a/README_clearlinux.md
+++ b/README_clearlinux.md
@@ -75,6 +75,10 @@ $ sudo chgrp ias_avb /dev/igb_avb
 $ sudo chmod 660 /dev/ptp*
 $ sudo chgrp ias_avb /dev/ptp*
 
+# If the module igb_avb is loaded by default on boot, reinsert the module: #
+$ rmmod igb_avb
+$ sudo insmod /lib/modules/<kernel-ver>/kernel/drivers/staging/igb_avb/igb_avb.ko tx_size=1024
+
 # Start the DLT daemon (for logging and tracing) #
 
 $ dlt-daemon -d (to daemonize)

--- a/README_dev.md
+++ b/README_dev.md
@@ -128,6 +128,10 @@ $ sudo chgrp ias_avb /dev/igb_avb
 $ sudo chmod 660 /dev/ptp*
 $ sudo chgrp ias_avb /dev/ptp*
 
+# If the module igb_avb is loaded by default on boot, reinsert the module: #
+$ rmmod igb_avb
+$ sudo insmod /lib/modules/<kernel-ver>/kernel/drivers/staging/igb_avb/igb_avb.ko tx_size=1024
+
 # Start the DLT daemon (for logging and tracing) #
 
 $ cd $AVB_DEPS/bin


### PR DESCRIPTION
Updates instructions for reinserting igb_avb module if the module
is loaded by default on boot